### PR TITLE
Star masks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ install:
       numpy \
       galsim \
       numba \
+      ngmix \
       lsstdesc.weaklensingdeblending \
       fitsio
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ install:
       pytest \
       numpy \
       galsim \
+      numba \
       lsstdesc.weaklensingdeblending \
       fitsio
 

--- a/descwl_shear_sims/gen_star_masks.py
+++ b/descwl_shear_sims/gen_star_masks.py
@@ -284,7 +284,6 @@ def add_bleed(*, mask, image, x, y, width, length, sat_val):
     intx = int(x)
     inty = int(y)
 
-    xpad = 0
     xmin = intx - xpad
     xmax = intx + xpad
 

--- a/descwl_shear_sims/gen_star_masks.py
+++ b/descwl_shear_sims/gen_star_masks.py
@@ -32,19 +32,19 @@ class StarMasks(object):
         Number of saturated stars per square degree, default 200
     radmean: float
         Mean star mask radius in pixels for log normal distribution,
-        default 3
+        default 1
     radstd: float
         Radius standard deviation in pixels for log normal distribution,
         default 5
     radmin: float
         Minimum radius in pixels of star masks.  The log normal values
-        will be clipped to more than this value. Default 3
+        will be clipped to more than this value. Default 2
     radmax: float
         Maximum radius in pixels of star masks.  The log normal values
-        will be clipped to less than this value. Default 500.
+        will be clipped to less than this value. Default 20.
     bleed_length_fac: float
         The bleed length is this factor times the *diameter* of the circular
-        star mask, default 2
+        star mask, default 4
     """
     def __init__(self, *,
                  rng,

--- a/descwl_shear_sims/gen_star_masks.py
+++ b/descwl_shear_sims/gen_star_masks.py
@@ -54,7 +54,7 @@ class StarMasks(object):
                  density=200,
                  radmean=1,
                  radstd=5,
-                 radmin=1,
+                 radmin=2,
                  radmax=20,
                  bleed_length_fac=4):
 
@@ -235,22 +235,22 @@ def add_star(*, mask, image, x, y, radius, sat_val):
         Radius of circle in pixels
     """
 
+    intx = int(x)
+    inty = int(y)
+
     radius2 = radius**2
     ny, nx = mask.shape
 
     for iy in range(ny):
-        y2 = (y-iy)**2
+        y2 = (inty-iy)**2
         if y2 > radius2:
             continue
 
         for ix in range(nx):
-            x2 = (x-ix)**2
-            if x2 > radius2:
-                continue
+            x2 = (intx-ix)**2
+            rad2 = x2 + y2
 
-            rad = x2 + y2
-
-            if rad > radius2:
+            if rad2 > radius2:
                 continue
 
             mask[iy, ix] |= SAT
@@ -281,11 +281,15 @@ def add_bleed(*, mask, image, x, y, width, length, sat_val):
     xpad = (width-1)//2
     ypad = (length-1)//2
 
-    xmin = x - xpad
-    xmax = x + xpad
+    intx = int(x)
+    inty = int(y)
 
-    ymin = y - ypad
-    ymax = y + ypad
+    xpad = 0
+    xmin = intx - xpad
+    xmax = intx + xpad
+
+    ymin = inty - ypad
+    ymax = inty + ypad
 
     for iy in range(ymin, ymax+1):
         if iy < 0 or iy > (ny-1):

--- a/descwl_shear_sims/gen_star_masks.py
+++ b/descwl_shear_sims/gen_star_masks.py
@@ -4,7 +4,7 @@ import galsim
 import ngmix
 from .randsphere import randcap
 
-from .lsst_bits import STAR, BLEED
+from .lsst_bits import SAT
 
 
 class StarMasks(object):
@@ -52,11 +52,11 @@ class StarMasks(object):
                  center_dec,
                  radius_degrees=5,
                  density=200,
-                 radmean=3,
+                 radmean=1,
                  radstd=5,
-                 radmin=3,
-                 radmax=500,
-                 bleed_length_fac=2):
+                 radmin=1,
+                 radmax=20,
+                 bleed_length_fac=4):
 
         area = np.pi*radius_degrees**2
         count = rng.poisson(lam=density*area)
@@ -235,7 +235,7 @@ def add_star(*, mask, x, y, radius):
             if rad > radius2:
                 continue
 
-            mask[iy, ix] |= STAR
+            mask[iy, ix] |= SAT
 
 
 @njit
@@ -273,4 +273,4 @@ def add_bleed(*, mask, x, y, width, length):
         for ix in range(xmin, xmax+1):
             if ix < 0 or ix > (nx-1):
                 continue
-            mask[iy, ix] |= BLEED
+            mask[iy, ix] |= SAT

--- a/descwl_shear_sims/gen_star_masks.py
+++ b/descwl_shear_sims/gen_star_masks.py
@@ -1,0 +1,303 @@
+import numpy as np
+from numba import njit
+import esutil as eu
+import ngmix
+
+
+def add_star_and_bleed_masks(*,
+                             rng,
+                             mask,
+                             wcs,
+                             density=200,
+                             pixel_scale=0.2,
+                             radmean=3,
+                             radstd=5,
+                             radmin=3,
+                             radmax=50,
+                             bleed_length_fac=2,
+                             mask_value=1):
+    """
+    make fake masks with
+
+    - star mask radii distributed as a clipped log normal
+    - bleed trail length a fixed factor larger than the diameter
+      of the star mask
+    - bleed widths either 1 or 2
+
+
+    Parameters
+    ----------
+    mask: ndarray
+        Integer mask image
+    rng: numpy.RandomState
+        Random number generator to use
+    density: float
+        Number of saturated stars per square degree
+    pixel_scale: float
+        pixel scale in arcsec/pixel
+    radmean: float
+        Mean radius for log normal distribution
+    radstd: float
+        Radius standard deviation for log normal distribution
+    radmin: float
+        Minimum radius of star masks
+    radmax: float
+        Maximum radius of star masks
+    bleed_length_fac: float
+        The bleed length is this factor times the *diameter* of the circular
+        star mask
+    mask_value: int
+        Value to put in mask
+
+    Returns
+    -------
+    nstars: int
+        Number of stars added
+    """
+
+    dims = mask.shape
+
+    x, y = get_locations_sqdeg(
+        rng=rng,
+        density=density,
+        dims=dims,
+        pixel_scale=pixel_scale,
+    )
+
+    rpdf = ngmix.priors.LogNormal(radmean, radstd, rng=rng)
+    nstars = x.size
+    for i in range(nstars):
+        star_mask_rad = get_star_mask_rad(
+            pdf=rpdf,
+            radmin=radmin,
+            radmax=radmax,
+        )
+        bleed_width = get_bleed_width(
+            rng=rng,
+            star_mask_rad=star_mask_rad,
+        )
+        bleed_length = get_bleed_length(
+            star_mask_rad=star_mask_rad,
+            bleed_length_fac=bleed_length_fac,
+        )
+        add_star_and_bleed(
+            mask=mask,
+            x=x[i],
+            y=y[i],
+            radius=star_mask_rad,
+            bleed_width=bleed_width,
+            bleed_length=bleed_length,
+            value=mask_value,
+        )
+
+    return nstars
+
+
+def add_star_and_bleed(*,
+                       mask,
+                       x, y,
+                       radius,
+                       bleed_width,
+                       bleed_length,
+                       value):
+
+    add_star(
+        mask=mask,
+        x=x,
+        y=y,
+        radius=radius,
+        value=value,
+    )
+
+    add_bleed(
+        mask=mask,
+        x=x,
+        y=y,
+        width=bleed_width,
+        length=bleed_length,
+        value=value,
+    )
+
+
+def get_star_mask_rad(*, pdf, radmin, radmax):
+
+    while True:
+        radius = pdf.sample()
+        if radmin < radius < radmax:
+            break
+
+    print('radius:', radius)
+    return radius
+
+
+def get_bleed_width(*, rng, star_mask_rad):
+    """
+    width is always odd
+    """
+
+    if star_mask_rad > 10:
+        return 3
+    else:
+        return 1
+
+
+def get_bleed_length(*, star_mask_rad, bleed_length_fac):
+    diameter = star_mask_rad*2
+    length = int(bleed_length_fac*diameter)
+
+    if length % 2 == 0:
+        length -= 1
+
+    if length < 0:
+        length = 1
+
+    return length
+
+
+@njit
+def add_star(*, mask, x, y, radius, value):
+
+    radius2 = radius**2
+    ny, nx = mask.shape
+
+    for iy in range(ny):
+        y2 = (y-iy)**2
+        if y2 > radius2:
+            continue
+
+        for ix in range(nx):
+            x2 = (x-ix)**2
+            if x2 > radius2:
+                continue
+
+            rad = x2 + y2
+
+            if rad > radius2:
+                continue
+
+            mask[iy, ix] |= value
+
+
+@njit
+def add_bleed(*, mask, x, y, length, width, value):
+    """
+    add odd width and odd length bleed
+    """
+
+    ny, nx = mask.shape
+
+    xpad = (width-1)//2
+    ypad = (length-1)//2
+
+    xmin = x - xpad
+    xmax = x + xpad
+
+    ymin = y - ypad
+    ymax = y + ypad
+
+    for iy in range(ymin, ymax+1):
+        if iy < 0 or iy > (ny-1):
+            continue
+
+        for ix in range(xmin, xmax+1):
+            if ix < 0 or ix > (nx-1):
+                continue
+            mask[iy, ix] |= value
+
+
+def get_locations_sqdeg(*, rng, density, dims, pixel_scale):
+
+    area_degrees = (
+        dims[0]*dims[1] * pixel_scale**2/3600.0**2
+    )
+    assert area_degrees < 1
+
+    count = rng.poisson(lam=density)
+    x, y = _get_locations_sqdeg(
+        rng=rng,
+        count=count,
+        dims=dims,
+        pixel_scale=pixel_scale,
+    )
+    w, = np.where(
+        (x >= 0) & (x < dims[1]) &
+        (y >= 0) & (y < dims[0])
+    )
+    print('found:', w.size)
+    x = x[w]
+    y = y[w]
+    return x, y
+
+
+def _get_locations_sqdeg(*, rng, count, dims, pixel_scale):
+
+    y = _get_locations_deg(
+        rng=rng,
+        count=count,
+        dim=dims[0],
+        pixel_scale=pixel_scale,
+    )
+    x = _get_locations_deg(
+        rng=rng,
+        count=count,
+        dim=dims[1],
+        pixel_scale=pixel_scale,
+    )
+
+    return x, y
+
+
+def _get_locations_deg(*, rng, count, dim, pixel_scale):
+
+    one_deg_pix = 1.0*3600/pixel_scale
+    cen = (dim-1.0)/2.0
+    min_fake_pix = cen - one_deg_pix/2
+    max_fake_pix = cen + one_deg_pix/2
+
+    vals = rng.uniform(
+        low=min_fake_pix,
+        high=max_fake_pix,
+        size=count,
+    )
+
+    return vals.astype('i4')
+
+
+def show_mask(*, mask):
+    import images
+    images.view(mask)
+
+
+def dotest(ntry=1000):
+    rng = np.random.RandomState()
+
+    pixel_scale = 0.2
+
+    # 1 arcmin
+    size_arcmin = 1.0
+    dims = [int(size_arcmin*60/pixel_scale)]*2
+
+    mask = np.zeros(dims, dtype='i4')
+
+    nwith = 0
+    for i in range(ntry):
+        mask[:, :] = 0
+
+        nstars = add_star_and_bleed_masks(
+            mask=mask,
+            rng=rng,
+            pixel_scale=pixel_scale,
+        )
+        if nstars > 0:
+            show_mask(mask=mask)
+            import fitsio
+            fitsio.write('test.fits', mask, clobber=True)
+            if input('hit a key (q to quit): ') == 'q':
+                return
+
+    frac = nwith/ntry
+    print('frac with star: %d/%d %g' % (nwith, ntry, frac))
+
+
+if __name__ == '__main__':
+    dotest()

--- a/descwl_shear_sims/gen_star_masks.py
+++ b/descwl_shear_sims/gen_star_masks.py
@@ -26,24 +26,25 @@ class StarMasks(object):
     center_dec: float
         Stars will be generated in a disk around this point
     radius_degrees: float
-        Stars will be in a disk with this radius
+        Stars will be generated in a disk with this radius around the coadd
+        center, default 5 degrees
     density: float
-        Number of saturated stars per square degree
-    pixel_scale: float
-        pixel scale in arcsec/pixel
+        Number of saturated stars per square degree, default 200
     radmean: float
-        Mean star mask radius in pixels for log normal distribution
+        Mean star mask radius in pixels for log normal distribution,
+        default 3
     radstd: float
-        Radius standard deviation in pixels for log normal distribution
+        Radius standard deviation in pixels for log normal distribution,
+        default 5
     radmin: float
         Minimum radius in pixels of star masks.  The log normal values
-        will be clipped to more than this value
+        will be clipped to more than this value. Default 3
     radmax: float
         Maximum radius in pixels of star masks.  The log normal values
-        will be clipped to less than this value
+        will be clipped to less than this value. Default 500.
     bleed_length_fac: float
         The bleed length is this factor times the *diameter* of the circular
-        star mask
+        star mask, default 2
     """
     def __init__(self, *,
                  rng,

--- a/descwl_shear_sims/lsst_bits.py
+++ b/descwl_shear_sims/lsst_bits.py
@@ -3,6 +3,7 @@ import warnings
 
 # default mask bits from the stack
 BAD_COLUMN = np.int64(2**0)
+SAT = np.int64(2**1)
 COSMIC_RAY = np.int64(2**3)
 EDGE = np.int64(2**4)
 
@@ -17,14 +18,15 @@ def _check_bits_against_stack():
     try:
         import lsst.afw.image as afw_image
 
-        mask = afw_image.Mask()
-        cr_val = 2**mask.getMaskPlane('CR')
-        bad_val = 2**mask.getMaskPlane('BAD')
-        edge_val = 2**mask.getMaskPlane('EDGE')
+        sat_val = afw_image.Mask.getPlaneBitMask('SAT')
+        cr_val = afw_image.Mask.getPlaneBitMask('CR')
+        bad_val = afw_image.Mask.getPlaneBitMask('BAD')
+        edge_val = afw_image.Mask.getPlaneBitMask('EDGE')
 
         if (cr_val != COSMIC_RAY or
                 bad_val != BAD_COLUMN or
-                edge_val != EDGE):
+                edge_val != EDGE or
+                sat_val != SAT):
             warnings.warn(
                 "simulation bit mask flags do not match those of the DM stack")
 

--- a/descwl_shear_sims/lsst_bits.py
+++ b/descwl_shear_sims/lsst_bits.py
@@ -6,6 +6,11 @@ BAD_COLUMN = np.int64(2**0)
 COSMIC_RAY = np.int64(2**3)
 EDGE = np.int64(2**4)
 
+# these are not official values, as far as I know
+# the stack doesn't mark such things (ES 2020-02-18)
+STAR = np.int64(2**10)
+BLEED = np.int64(2**11)
+
 
 # double check they match the stack
 def _check_bits_against_stack():

--- a/descwl_shear_sims/randsphere.py
+++ b/descwl_shear_sims/randsphere.py
@@ -1,4 +1,117 @@
 import numpy as np
+import esutil as eu
+
+
+def randcap(*,
+            rng,
+            nrand,
+            ra,
+            dec,
+            radius,
+            get_radius=False,
+            dorot=False):
+    """
+    Generate random points in a sherical cap
+
+    parameters
+    ----------
+
+    nrand:
+        The number of random points
+    ra,dec:
+        The center of the cap in degrees.  The ra should be within [0,360) and
+        dec from [-90,90]
+    radius: float
+        radius of the cap, same units as ra,dec
+    get_radius: bool, optional
+        if true, return radius of each point in radians
+    dorot: bool
+        If dorot is True, generate the points on the equator and rotate them to
+        be centered at the desired location.  This is the default when the dec
+        is within 0.1 degrees of the pole, to avoid calculation issues
+    """
+
+    # generate uniformly in r**2
+    if dec >= 89.9 or dec <= -89.9:
+        dorot = True
+
+    if dorot:
+        tra, tdec = 90.0, 0.0
+        rand_ra, rand_dec, rand_r = randcap(
+            rng=rng,
+            nrand=nrand,
+            ra=90.0,
+            dec=0.0,
+            radius=radius,
+            get_radius=True,
+        )
+        rand_ra, rand_dec = eu.coords.rotate(
+            0.0,
+            dec-tdec,
+            0.0,
+            rand_ra,
+            rand_dec,
+        )
+        rand_ra, rand_dec = eu.coords.rotate(
+            ra-tra,
+            0.0,
+            0.0,
+            rand_ra,
+            rand_dec,
+        )
+    else:
+
+        rand_r = rng.uniform(size=nrand)
+        rand_r = np.sqrt(rand_r)*radius
+
+        # put in degrees
+        np.deg2rad(rand_r, rand_r)
+
+        # generate position angle uniformly 0, 2*PI
+        rand_posangle = rng.uniform(low=0, high=2*np.pi, size=nrand)
+
+        theta = np.array(dec, dtype='f8', ndmin=1, copy=True)
+        phi = np.array(ra, dtype='f8', ndmin=1, copy=True)
+        theta += 90
+
+        np.deg2rad(theta, theta)
+        np.deg2rad(phi, phi)
+
+        sintheta = np.sin(theta)
+        costheta = np.cos(theta)
+
+        sinr = np.sin(rand_r)
+        cosr = np.cos(rand_r)
+
+        cospsi = np.cos(rand_posangle)
+        costheta2 = costheta*cosr + sintheta*sinr*cospsi
+
+        np.clip(costheta2, -1, 1, costheta2)
+
+        # gives [0,pi)
+        theta2 = np.arccos(costheta2)
+        sintheta2 = np.sin(theta2)
+
+        cos_dphi = (cosr - costheta*costheta2)/(sintheta*sintheta2)
+
+        np.clip(cos_dphi, -1, 1, cos_dphi)
+        dphi = np.arccos(cos_dphi)
+
+        # note fancy usage of where
+        phi2 = np.where(rand_posangle > np.pi, phi+dphi, phi-dphi)
+
+        np.rad2deg(phi2, phi2)
+        np.rad2deg(theta2, theta2)
+        rand_ra = phi2
+        rand_dec = theta2-90.0
+
+        eu.coords.atbound(rand_ra, 0.0, 360.0)
+
+    if get_radius:
+        np.rad2deg(rand_r, rand_r)
+        return rand_ra, rand_dec, rand_r
+    else:
+        return rand_ra, rand_dec
 
 
 def randsphere(rng, num, ra_range=None, dec_range=None):

--- a/descwl_shear_sims/simple_sim.py
+++ b/descwl_shear_sims/simple_sim.py
@@ -213,6 +213,32 @@ class Sim(object):
                 one entry per bad column width in `widths`.
 
         See descwl_shear_sims.gen_masks.generate_bad_columns for the defaults.
+    stars: bool, optional
+        If `True` then add star and bleed trail masks. Default is `False`.
+    stars_kws : dict, optional
+        A dictionary of options for generating star and bleed trail masks
+
+            radius_degrees: float
+                Stars will be generated in a disk with this radius around
+                the coadd center, default 5 degrees
+            density: float
+                Number of saturated stars per square degree, default 200
+            radmean: float
+                Mean star mask radius in pixels for log normal distribution,
+                default 3
+            radstd: float
+                Radius standard deviation in pixels for log normal distribution,
+                default 5
+            radmin: float
+                Minimum radius in pixels of star masks.  The log normal values
+                will be clipped to more than this value.  Default 3
+            radmax: float
+                Maximum radius in pixels of star masks.  The log normal values
+                will be clipped to less than this value. Default 500
+            bleed_length_fac: float
+                The bleed length is this factor times the *diameter* of the
+                circular star mask, default 2
+
 
     Methods
     -------

--- a/descwl_shear_sims/tests/test_gen_star_masks.py
+++ b/descwl_shear_sims/tests/test_gen_star_masks.py
@@ -10,6 +10,9 @@ from ..simple_sim import Sim
 
 
 def test_star_mask_smoke():
+    """
+    make sure we can generate star masks
+    """
     rng = np.random.RandomState(2342)
     ra = 200.0
     dec = 15.0
@@ -22,6 +25,9 @@ def test_star_mask_smoke():
 
 
 def test_star_mask_works():
+    """
+    test star masking, adding them directly to existing mask image
+    """
     rng = np.random.RandomState(234)
     sim = Sim(
         rng=rng,
@@ -45,6 +51,30 @@ def test_star_mask_works():
     mask = se_obs.bmask.array
     nstars = star_masks.set_mask(mask=mask, wcs=wcs)
     assert nstars > 0
+
+    w = np.where((mask & STAR) != 0)
+    assert w[0].size > 0
+    w = np.where((mask & BLEED) != 0)
+    assert w[0].size > 0
+
+
+def test_star_mask_keywords():
+    """
+    test star masking using the keyword to the sim
+    """
+    rng = np.random.RandomState(234)
+    sim = Sim(
+        rng=rng,
+        bands=['r'],
+        epochs_per_band=1,
+        stars=True,
+        stars_kws={'density': 10000},
+    )
+
+    data = sim.gen_sim()
+
+    se_obs = data['r'][0]
+    mask = se_obs.bmask.array
 
     w = np.where((mask & STAR) != 0)
     assert w[0].size > 0

--- a/descwl_shear_sims/tests/test_gen_star_masks.py
+++ b/descwl_shear_sims/tests/test_gen_star_masks.py
@@ -1,0 +1,52 @@
+"""
+copy-paste from my (beckermr) personal code here
+https://github.com/beckermr/metadetect-coadding-sims
+"""
+import numpy as np
+
+from ..gen_star_masks import StarMasks
+from ..lsst_bits import STAR, BLEED
+from ..simple_sim import Sim
+
+
+def test_star_mask_smoke():
+    rng = np.random.RandomState(2342)
+    ra = 200.0
+    dec = 15.0
+
+    StarMasks(
+        rng=rng,
+        center_ra=ra,
+        center_dec=dec,
+    )
+
+
+def test_star_mask_works():
+    rng = np.random.RandomState(234)
+    sim = Sim(
+        rng=rng,
+        bands=['r'],
+        epochs_per_band=1,
+    )
+
+    data = sim.gen_sim()
+    center_ra = sim._world_origin.ra.deg
+    center_dec = sim._world_origin.dec.deg
+
+    # very high density to ensure we get one
+    star_masks = StarMasks(
+        rng=rng,
+        center_ra=center_ra,
+        center_dec=center_dec,
+        density=10000,
+    )
+    se_obs = data['r'][0]
+    wcs = se_obs.wcs
+    mask = se_obs.bmask.array
+    nstars = star_masks.set_mask(mask=mask, wcs=wcs)
+    assert nstars > 0
+
+    w = np.where((mask & STAR) != 0)
+    assert w[0].size > 0
+    w = np.where((mask & BLEED) != 0)
+    assert w[0].size > 0

--- a/descwl_shear_sims/tests/test_gen_star_masks.py
+++ b/descwl_shear_sims/tests/test_gen_star_masks.py
@@ -1,7 +1,3 @@
-"""
-copy-paste from my (beckermr) personal code here
-https://github.com/beckermr/metadetect-coadding-sims
-"""
 import numpy as np
 
 from ..gen_star_masks import StarMasks
@@ -80,3 +76,31 @@ def test_star_mask_keywords():
     assert w[0].size > 0
     w = np.where((mask & BLEED) != 0)
     assert w[0].size > 0
+
+
+def test_star_mask_repeatable():
+    """
+    test star masking using the keyword to the sim
+    """
+
+    for trial in (1, 2):
+        rng = np.random.RandomState(234)
+        sim = Sim(
+            rng=rng,
+            bands=['r'],
+            epochs_per_band=1,
+            stars=True,
+            stars_kws={'density': 10000},
+        )
+
+        data = sim.gen_sim()
+
+        se_obs = data['r'][0]
+        mask = se_obs.bmask.array
+
+        w = np.where(((mask & STAR) != 0) | ((mask & BLEED) != 0))
+
+        if trial == 1:
+            nmarked = w[0].size
+        else:
+            assert w[0].size == nmarked

--- a/descwl_shear_sims/tests/test_gen_star_masks.py
+++ b/descwl_shear_sims/tests/test_gen_star_masks.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from ..gen_star_masks import StarMasks
-from ..lsst_bits import STAR, BLEED
+from ..lsst_bits import SAT
 from ..simple_sim import Sim
 
 
@@ -48,9 +48,7 @@ def test_star_mask_works():
     nstars = star_masks.set_mask(mask=mask, wcs=wcs)
     assert nstars > 0
 
-    w = np.where((mask & STAR) != 0)
-    assert w[0].size > 0
-    w = np.where((mask & BLEED) != 0)
+    w = np.where((mask & SAT) != 0)
     assert w[0].size > 0
 
 
@@ -72,9 +70,7 @@ def test_star_mask_keywords():
     se_obs = data['r'][0]
     mask = se_obs.bmask.array
 
-    w = np.where((mask & STAR) != 0)
-    assert w[0].size > 0
-    w = np.where((mask & BLEED) != 0)
+    w = np.where((mask & SAT) != 0)
     assert w[0].size > 0
 
 
@@ -98,7 +94,7 @@ def test_star_mask_repeatable():
         se_obs = data['r'][0]
         mask = se_obs.bmask.array
 
-        w = np.where(((mask & STAR) != 0) | ((mask & BLEED) != 0))
+        w = np.where((mask & SAT) != 0)
 
         if trial == 1:
             nmarked = w[0].size

--- a/descwl_shear_sims/tests/test_gen_star_masks.py
+++ b/descwl_shear_sims/tests/test_gen_star_masks.py
@@ -2,7 +2,10 @@ import numpy as np
 
 from ..gen_star_masks import StarMasks
 from ..lsst_bits import SAT
-from ..simple_sim import Sim
+from ..simple_sim import (
+    Sim,
+    SAT_VAL,
+)
 
 
 def test_star_mask_smoke():
@@ -45,7 +48,14 @@ def test_star_mask_works():
     se_obs = data['r'][0]
     wcs = se_obs.wcs
     mask = se_obs.bmask.array
-    nstars = star_masks.set_mask(mask=mask, wcs=wcs)
+    image = se_obs.image.array
+    xvals, yvals = star_masks.set_mask_and_image(
+        mask=mask,
+        image=image,
+        wcs=wcs,
+        sat_val=SAT_VAL,
+    )
+    nstars = xvals.size
     assert nstars > 0
 
     w = np.where((mask & SAT) != 0)
@@ -61,8 +71,8 @@ def test_star_mask_keywords():
         rng=rng,
         bands=['r'],
         epochs_per_band=1,
-        stars=True,
-        stars_kws={'density': 10000},
+        sat_stars=True,
+        sat_stars_kws={'density': 10000},
     )
 
     data = sim.gen_sim()
@@ -85,8 +95,8 @@ def test_star_mask_repeatable():
             rng=rng,
             bands=['r'],
             epochs_per_band=1,
-            stars=True,
-            stars_kws={'density': 10000},
+            sat_stars=True,
+            sat_stars_kws={'density': 10000},
         )
 
         data = sim.gen_sim()

--- a/descwl_shear_sims/tests/test_lsst_mask_bits.py
+++ b/descwl_shear_sims/tests/test_lsst_mask_bits.py
@@ -10,6 +10,7 @@ from ..lsst_bits import (
     COSMIC_RAY,
     BAD_COLUMN,
     EDGE,
+    SAT,
 )
 
 
@@ -23,3 +24,6 @@ def test_lsst_mask_bits():
 
     edge_val = 2**afw_image.Mask.getMaskPlane('EDGE')
     assert edge_val == EDGE
+
+    sat_val = 2**afw_image.Mask.getMaskPlane('SAT')
+    assert sat_val == SAT


### PR DESCRIPTION
closes #43 
closes #44 

At this point there are heuristics for star radii and bleed trail properties, but we can alter it to take in those values if we get a catalog of these from DC2

I defined bits for these, there are no bits in the official lsst code

TODO is to add this to the simple_sim code with keywords star bool and star_kws