### PR TITLE
generalize bright region marking

### DIFF
--- a/descwl_shear_sims/lsst_bits.py
+++ b/descwl_shear_sims/lsst_bits.py
@@ -9,7 +9,7 @@ EDGE = np.int32(2**4)
 
 # these are not official values, as far as I know
 # the stack doesn't mark such things (ES 2020-02-18)
-BRIGHT_STAR = np.int32(2**30)
+BRIGHT = np.int32(2**30)
 
 
 # double check they match the stack

--- a/descwl_shear_sims/saturation.py
+++ b/descwl_shear_sims/saturation.py
@@ -1,3 +1,4 @@
+import numpy as np
 from numba import njit
 from .lsst_bits import SAT
 from .sim_constants import ZERO_POINT
@@ -11,15 +12,15 @@ BAND_SAT_VALS = {
     'z': 140000 * 10.0**(0.4*(ZERO_POINT-31.50)),
 }
 
-# From the LSST science book
-# mag to saturate for 30 second exposures, need this for the
-# longer exposures, so for now just add one TODO
+# From the LSST science book at 15 seconds
+# convert for 30 second exposures
+ltwo = np.log10(2)
 BAND_STAR_MAG_SAT = {
-    'u': 14.7+1,
-    'g': 15.7+1,
-    'r': 15.8+1,
-    'i': 15.8+1,
-    'z': 15.3+1,
+    'u': 14.7 + ltwo,
+    'g': 15.7 + ltwo,
+    'r': 15.8 + ltwo,
+    'i': 15.8 + ltwo,
+    'z': 15.3 + ltwo,
 }
 
 

--- a/descwl_shear_sims/simple_sim.py
+++ b/descwl_shear_sims/simple_sim.py
@@ -728,7 +728,7 @@ class Sim(object):
         all_data = self._generate_objects()
 
         if self.bright_strategy == 'fold':
-            self._set_folding_thresholds(all_data)
+            self._set_gsparams(all_data)
 
         band_data = OrderedDict()
         for band_ind, band in enumerate(self.bands):
@@ -808,7 +808,7 @@ class Sim(object):
 
         return band_data
 
-    def _set_folding_thresholds(self, all_objs):
+    def _set_gsparams(self, all_objs):
         """Function due to M Jarvis. Attempts to set the folding threshold
         so that we render will into the noise in the final coadded image.
         """

--- a/descwl_shear_sims/simple_sim.py
+++ b/descwl_shear_sims/simple_sim.py
@@ -1035,21 +1035,17 @@ class Sim(object):
         return all_data
 
     def _keep_star(self, star):
-        """remove stars under certain conditions
+        """
+        remove stars under certain conditions
 
         the conditions are:
           - too bright
-          - saturated
         """
         keep = True
 
         min_mag = self.stars_kws.get('min_mag', None)
         if min_mag is not None:
             if any((star[band]['mag'] < min_mag for band in star)):
-                keep = False
-
-        if not self.sat_stars:
-            if any((star[band]['saturated'] for band in star)):
                 keep = False
 
         return keep

--- a/descwl_shear_sims/simple_sim.py
+++ b/descwl_shear_sims/simple_sim.py
@@ -1037,6 +1037,7 @@ class Sim(object):
     def _keep_star(self, star):
         """
         remove stars under certain conditions
+        Note this no longer checks saturated
 
         the conditions are:
           - too bright

--- a/descwl_shear_sims/stars.py
+++ b/descwl_shear_sims/stars.py
@@ -16,7 +16,8 @@ def sample_fixed_star(*,
                       bands,
                       sat_stars,
                       sat_stars_frac,
-                      star_mask_pdf):
+                      star_mask_pdf,
+                      flux_funcs):
     """
     Returns
     -------
@@ -31,10 +32,10 @@ def sample_fixed_star(*,
             saturated = True
             sat_data = star_mask_pdf.sample()
 
-    flux = 10**(0.4 * (30 - mag))
-
     star = OrderedDict()
     for band in bands:
+
+        flux = flux_funcs[band](mag)
         obj = galsim.Gaussian(fwhm=1.0e-4).withFlux(flux)
 
         star[band] = {
@@ -52,7 +53,7 @@ def sample_fixed_star(*,
 def sample_star(*,
                 rng,
                 star_data,
-                surveys,
+                flux_funcs,
                 bands,
                 sat_stars,
                 star_mask_pdf=None):
@@ -65,7 +66,7 @@ def sample_star(*,
     for band in bands:
         bstar = {'type': 'star'}
         bstar['mag'] = get_star_mag(stars=star_data, index=star_ind, band=band)
-        bstar['flux'] = surveys[band].get_flux(bstar['mag'])
+        bstar['flux'] = flux_funcs[band](bstar['mag'])
 
         bstar['obj'] = galsim.Gaussian(
             fwhm=1.0e-4,

--- a/descwl_shear_sims/tests/test_simple_sim.py
+++ b/descwl_shear_sims/tests/test_simple_sim.py
@@ -3,6 +3,7 @@ import numpy as np
 
 from ..se_obs import SEObs
 from ..simple_sim import Sim
+from ..sim_constants import ZERO_POINT
 
 
 def test_simple_sim_smoke():
@@ -342,3 +343,36 @@ def test_simple_sim_grid_stars_and_gals_smoke():
                 fig, axs = plt.subplots(nrows=1, ncols=1, figsize=(8, 8))
                 axs.imshow(se_obs.image.array)
                 assert False
+
+
+@pytest.mark.parametrize('gals_type', ['exp', 'wldeblend'])
+def test_simple_sim_mag_zp(gals_type):
+    """
+    simulate a single star and make sure we get back the right
+    magnitude
+    """
+
+    star_mag = 16
+    sim = Sim(
+        rng=10,
+        epochs_per_band=1,
+        bands=['r'],
+        coadd_dim=33,
+        buff=0,
+        edge_width=2,
+        gals=False,
+        gals_type=gals_type,
+        layout_type='grid',
+        layout_kws={'dim': 1},
+        stars=True,
+        stars_type='fixed',
+        stars_kws={'mag': star_mag},
+    )
+
+    data = sim.gen_sim()
+
+    for band, bdata in data.items():
+        for se_obs in bdata:
+            im = se_obs.image.array
+            mag = ZERO_POINT - 2.5*np.log10(im.sum())
+            assert abs(mag-star_mag) < 0.1

--- a/descwl_shear_sims/tests/test_simple_sim.py
+++ b/descwl_shear_sims/tests/test_simple_sim.py
@@ -352,27 +352,31 @@ def test_simple_sim_mag_zp(gals_type):
     magnitude
     """
 
-    star_mag = 16
-    sim = Sim(
-        rng=10,
-        epochs_per_band=1,
-        bands=['r'],
-        coadd_dim=33,
-        buff=0,
-        edge_width=2,
-        gals=False,
-        gals_type=gals_type,
-        layout_type='grid',
-        layout_kws={'dim': 1},
-        stars=True,
-        stars_type='fixed',
-        stars_kws={'mag': star_mag},
-    )
+    try:
+        star_mag = 16
+        sim = Sim(
+            rng=10,
+            epochs_per_band=1,
+            bands=['r'],
+            coadd_dim=33,
+            buff=0,
+            edge_width=2,
+            gals=False,
+            gals_type=gals_type,
+            layout_type='grid',
+            layout_kws={'dim': 1},
+            stars=True,
+            stars_type='fixed',
+            stars_kws={'mag': star_mag},
+        )
 
-    data = sim.gen_sim()
+        data = sim.gen_sim()
 
-    for band, bdata in data.items():
-        for se_obs in bdata:
-            im = se_obs.image.array
-            mag = ZERO_POINT - 2.5*np.log10(im.sum())
-            assert abs(mag-star_mag) < 0.1
+        for band, bdata in data.items():
+            for se_obs in bdata:
+                im = se_obs.image.array
+                mag = ZERO_POINT - 2.5*np.log10(im.sum())
+                assert abs(mag-star_mag) < 0.1
+
+    except OSError:
+        pass


### PR DESCRIPTION
if any object has saturation it will get a bright mask
This is done for all bands even if sat is in one band

The motivation for this sort of thing is to give downstream codes enough information to avoid trying to deconvolve parts of the image that will cause artifacts.

If we had a reliable way to identify bright objects in the presence of saturation downstream we might be able to avoid putting this code in the sim, but I don't think we have that yet.  In general we might rely on external catalogs to do this in real data (all the bright objects are known).