### PR TITLE
use json file with list of example headers

### DIFF
--- a/descwl_shear_sims/cache_tools.py
+++ b/descwl_shear_sims/cache_tools.py
@@ -5,8 +5,3 @@ import fitsio
 @functools.lru_cache(maxsize=8)
 def cached_catalog_read(fname):
     return fitsio.read(fname)
-
-
-@functools.lru_cache(maxsize=8)
-def cached_header_read(*, fname, ext):
-    return fitsio.read_header(fname, ext=ext)


### PR DESCRIPTION
closes #101 

This uses a gzipped json file with a list of examples provided by Jim Chiang

I didn't modify the catalog cache maxsize since we currently only read a single catalog ever

I removed the header cache function, not used, instead a new one in the sip module