### PR TITLE
add back ability to control trimming of stamps

### DIFF
--- a/descwl_shear_sims/simple_sim.py
+++ b/descwl_shear_sims/simple_sim.py
@@ -330,6 +330,7 @@ class Sim(object):
         stars_type='fixed',
         stars_kws=None,
         star_bleeds=False,
+        trim_stamps=True,
     ):
         self._rng = (
             rng
@@ -347,6 +348,7 @@ class Sim(object):
         ########################################
         # rendering
         self.saturate = saturate  # will be forced True if star_bleeds is True
+        self.trim_stamps = trim_stamps
 
         ########################################
         # band structure
@@ -779,6 +781,7 @@ class Sim(object):
                     g2=self.g2,
                     shear_scene=self.shear_scene,
                     threshold=self.noise_per_band[band_ind],
+                    trim_stamps=self.trim_stamps,
                 )
 
                 se_image += self._generate_noise_image(band_ind)

--- a/descwl_shear_sims/simple_sim.py
+++ b/descwl_shear_sims/simple_sim.py
@@ -280,6 +280,11 @@ class Sim(object):
     star_bleeds: bool, optional
         If `True` then add bleeds. Default is `False`.
 
+    trim_stamps: bool, optional
+        If True, trim the stamps copied into the images.  This is to prevent
+        the star images from getting too large and galsim raising exceptions.
+        Default True.
+
     Methods
     -------
     gen_sim()


### PR DESCRIPTION
When trying to replicate the old runs, this was a missing feature.