### PR TITLE
trivial sim feature parity

### DIFF
--- a/descwl_shear_sims/__init__.py
+++ b/descwl_shear_sims/__init__.py
@@ -6,4 +6,5 @@ from .simple_sim import Sim
 from .trivial_sim import (
     make_trivial_sim,
     get_trivial_sim_config,
+    make_galaxy_catalog,
 )

--- a/descwl_shear_sims/__init__.py
+++ b/descwl_shear_sims/__init__.py
@@ -3,4 +3,7 @@ __version__ = '0.3.0'
 
 from .se_obs import SEObs
 from .simple_sim import Sim
-from .trivial_sim import TrivialSim
+from .trivial_sim import (
+    make_trivial_sim,
+    get_trivial_sim_config,
+)

--- a/descwl_shear_sims/gen_star_masks.py
+++ b/descwl_shear_sims/gen_star_masks.py
@@ -2,27 +2,27 @@ from numba import njit
 
 
 @njit
-def add_bright_star_mask(*, mask, x, y, radius, val):
+def add_bright_star_mask(*, bmask, x, y, radius, val):
     """
     Add a circular bright star mask to the input mask image
 
     Parameters
     ----------
-    mask: array
+    bmask: array
         Integer image
     x, y: floats
         The center position of the circle
     radius: float
         Radius of circle in pixels
     val: int
-        Val to or into mask
+        Val to "or" into bmask
     """
 
     intx = int(x)
     inty = int(y)
 
     radius2 = radius**2
-    ny, nx = mask.shape
+    ny, nx = bmask.shape
 
     for iy in range(ny):
         y2 = (inty-iy)**2
@@ -36,4 +36,4 @@ def add_bright_star_mask(*, mask, x, y, radius, val):
             if rad2 > radius2:
                 continue
 
-            mask[iy, ix] |= val
+            bmask[iy, ix] |= val

--- a/descwl_shear_sims/saturation.py
+++ b/descwl_shear_sims/saturation.py
@@ -13,17 +13,17 @@ BAND_SAT_VALS = {
 
 
 @njit
-def saturate_image_and_mask(*, image, mask, sat_val):
+def saturate_image_and_mask(*, image, bmask, sat_val):
     """
     clip image values at saturation and set the SAT mask bit.  Note
-    if the mask already has SAT set, then the value will also be set
+    if the bmask already has SAT set, then the value will also be set
 
     Parameters
     ----------
     image: ndarray
         The image to clip
-    mask: ndarray
-        The mask image
+    bmask: ndarray
+        The bitmask image
     sat_val: float
         The saturation value to use
     """
@@ -31,6 +31,6 @@ def saturate_image_and_mask(*, image, mask, sat_val):
 
     for row in range(ny):
         for col in range(nx):
-            if (mask[row, col] & SAT) != 0 or image[row, col] > sat_val:
+            if (bmask[row, col] & SAT) != 0 or image[row, col] > sat_val:
                 image[row, col] = sat_val
-                mask[row, col] |= SAT
+                bmask[row, col] |= SAT

--- a/descwl_shear_sims/saturation.py
+++ b/descwl_shear_sims/saturation.py
@@ -15,7 +15,8 @@ BAND_SAT_VALS = {
 @njit
 def saturate_image_and_mask(*, image, mask, sat_val):
     """
-    clip image values at saturation and set the SAT mask bit
+    clip image values at saturation and set the SAT mask bit.  Note
+    if the mask already has SAT set, then the value will also be set
 
     Parameters
     ----------
@@ -30,6 +31,6 @@ def saturate_image_and_mask(*, image, mask, sat_val):
 
     for row in range(ny):
         for col in range(nx):
-            if image[row, col] > sat_val:
+            if (mask[row, col] & SAT) != 0 or image[row, col] > sat_val:
                 image[row, col] = sat_val
                 mask[row, col] |= SAT

--- a/descwl_shear_sims/simple_sim.py
+++ b/descwl_shear_sims/simple_sim.py
@@ -950,7 +950,7 @@ class Sim(object):
         if self.saturate:
             saturate_image_and_mask(
                 image=se_image.array,
-                mask=bmask,
+                bmask=bmask,
                 sat_val=sat_val,
             )
 

--- a/descwl_shear_sims/simple_sim.py
+++ b/descwl_shear_sims/simple_sim.py
@@ -1399,7 +1399,7 @@ def add_bright_star_masks(obj_data, band_data):
                             pos = odata[band]['pos'][epoch]
                             bmask = band_data[band][epoch].bmask.array
                             add_bright_star_mask(
-                                mask=bmask, x=pos.x, y=pos.y,
+                                bmask=bmask, x=pos.x, y=pos.y,
                                 radius=radius,
                                 val=BRIGHT,
                             )

--- a/descwl_shear_sims/tests/test_correlated_noise.py
+++ b/descwl_shear_sims/tests/test_correlated_noise.py
@@ -1,0 +1,94 @@
+import pytest
+import numpy as np
+from descwl_shear_sims.trivial_sim import (
+    make_trivial_sim,
+    FixedGalaxyCatalog,
+    make_psf,
+)
+from numba import njit
+
+
+@njit
+def get_cov(image):
+
+    cov = np.zeros((3, 3))
+
+    nrow, ncol = image.shape
+    for row in range(1, nrow-1):
+        for col in range(1, ncol-1):
+
+            cenval = image[row, col]
+            for row_offset in range(-1, 1+1):
+                for col_offset in range(-1, 1+1):
+                    val = image[row+row_offset, col+col_offset]
+
+                    cov[row_offset+1, col_offset+1] += cenval*val
+    npix = (nrow - 2)*(ncol - 2)
+    cov *= 1.0/npix
+    return cov
+
+
+def test_correlated_noise():
+    """
+    use mag 37 galaxies so the image is purely noise,
+    and compare statistics with the coadded noise image
+    """
+    coadd_mod = pytest.importorskip('descwl_coadd.coadd')
+
+    rng0 = np.random.RandomState(97756)
+    ntrial = 100
+    for i in range(ntrial):
+        seed = rng0.randint(0, 2**30)
+        rng = np.random.RandomState(seed)
+
+        coadd_dim = 301
+        galaxy_catalog = FixedGalaxyCatalog(
+            rng=rng,
+            coadd_dim=coadd_dim,
+            buff=0,
+            layout="grid",
+            mag=37.0,
+            hlr=0.5,
+        )
+
+        psf = make_psf(psf_type="gauss")
+        sim_data = make_trivial_sim(
+            rng=rng,
+            galaxy_catalog=galaxy_catalog,
+            coadd_dim=coadd_dim,
+            g1=0.02,
+            g2=0.00,
+            psf=psf,
+            dither=True,
+            rotate=True,
+        )
+
+        mbc = coadd_mod.MultiBandCoadds(
+            rng=rng,
+            data=sim_data['band_data'],
+            coadd_wcs=sim_data['coadd_wcs'],
+            coadd_dims=sim_data['coadd_dims'],
+            psf_dims=sim_data['psf_dims'],
+            byband=False,
+            loglevel="debug",
+        )
+
+        coadd_obs = mbc.coadds['all']
+        image = coadd_obs.image
+        noise = coadd_obs.noise
+
+        icov = get_cov(image)
+        ncov = get_cov(noise)
+
+        if i == 0:
+            icov_sum = icov
+            ncov_sum = ncov
+        else:
+            icov_sum += icov
+            ncov_sum += ncov
+
+    icov = icov_sum/ntrial
+    ncov = ncov_sum/ntrial
+    fracdiff = ncov/icov - 1
+
+    assert np.all(np.abs(fracdiff) < 0.01)

--- a/descwl_shear_sims/tests/test_gen_star_masks.py
+++ b/descwl_shear_sims/tests/test_gen_star_masks.py
@@ -1,10 +1,47 @@
 import os
 import numpy as np
+import galsim
 import pytest
 
 from ..lsst_bits import SAT, BRIGHT
 from ..saturation import BAND_SAT_VALS
 from ..simple_sim import Sim
+from ..gen_star_masks import add_bright_star_mask
+from ..star_bleeds import add_bleed
+
+
+@pytest.mark.skipif(
+    "CATSIM_DIR" not in os.environ,
+    reason='simulation input data is not present')
+@pytest.mark.parametrize('band', ('r', 'i', 'z'))
+def test_star_bleed(band):
+    dims = (100, 100)
+
+    cen = [50, 50]
+
+    image = np.zeros(dims)
+    bmask = np.zeros(dims, dtype='i4')
+    pos = galsim.PositionD(x=cen[1], y=cen[0])
+    mag = 12
+    band = 'i'
+
+    add_bleed(
+        image=image,
+        bmask=bmask,
+        pos=pos,
+        mag=mag,
+        band=band,
+    )
+    add_bright_star_mask(
+        mask=bmask,
+        x=pos.x,
+        y=pos.y,
+        radius=10,
+        val=BRIGHT,
+    )
+
+    assert bmask[cen[0], cen[1]] == SAT | BRIGHT
+    assert image[cen[0], cen[1]] == BAND_SAT_VALS[band]
 
 
 @pytest.mark.skipif(

--- a/descwl_shear_sims/tests/test_gen_star_masks.py
+++ b/descwl_shear_sims/tests/test_gen_star_masks.py
@@ -33,7 +33,7 @@ def test_star_bleed(band):
         band=band,
     )
     add_bright_star_mask(
-        mask=bmask,
+        bmask=bmask,
         x=pos.x,
         y=pos.y,
         radius=10,

--- a/descwl_shear_sims/tests/test_trivial_sim.py
+++ b/descwl_shear_sims/tests/test_trivial_sim.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 import numpy as np
 from ..trivial_sim import (
@@ -120,6 +121,31 @@ def test_trivial_sim_layout(layout):
         coadd_dim=coadd_dim,
         buff=30,
         layout=layout,
+    )
+
+    _ = make_trivial_sim(
+        rng=rng,
+        galaxy_catalog=galaxy_catalog,
+        coadd_dim=coadd_dim,
+        g1=0.02,
+        g2=0.00,
+    )
+
+
+@pytest.mark.skipif(
+    "CATSIM_DIR" not in os.environ,
+    reason='simulation input data is not present',
+)
+def test_trivial_sim_wldeblend():
+    seed = 7421
+    coadd_dim = 201
+    rng = np.random.RandomState(seed)
+
+    galaxy_catalog = make_galaxy_catalog(
+        rng=rng,
+        gal_type="wldeblend",
+        coadd_dim=coadd_dim,
+        buff=30,
     )
 
     _ = make_trivial_sim(

--- a/descwl_shear_sims/tests/test_trivial_sim.py
+++ b/descwl_shear_sims/tests/test_trivial_sim.py
@@ -203,6 +203,7 @@ def test_trivial_sim_wldeblend():
         psf=psf,
     )
 
+
 @pytest.mark.skipif(
     "CATSIM_DIR" not in os.environ,
     reason='simulation input data is not present',

--- a/descwl_shear_sims/tests/test_trivial_sim.py
+++ b/descwl_shear_sims/tests/test_trivial_sim.py
@@ -5,6 +5,8 @@ from ..trivial_sim import (
     make_trivial_sim,
     make_galaxy_catalog,
     make_psf,
+    make_ps_psf,
+    get_se_dim,
 )
 
 
@@ -77,6 +79,39 @@ def test_trivial_sim():
     band_data = sim_data['band_data']
     for band in bands:
         assert band in band_data
+
+
+@pytest.mark.parametrize("psf_type", ["gauss", "moffat", "ps"])
+def test_trivial_sim_psf_type(psf_type):
+
+    seed = 431
+    rng = np.random.RandomState(seed)
+
+    coadd_dim = 101
+    galaxy_catalog = make_galaxy_catalog(
+        rng=rng,
+        gal_type="exp",
+        coadd_dim=coadd_dim,
+        buff=5,
+        layout="grid",
+    )
+
+    if psf_type == "ps":
+        se_dim = get_se_dim(coadd_dim=coadd_dim)
+        psf = make_ps_psf(rng=rng, dim=se_dim)
+    else:
+        psf = make_psf(psf_type=psf_type)
+
+    _ = make_trivial_sim(
+        rng=rng,
+        galaxy_catalog=galaxy_catalog,
+        coadd_dim=coadd_dim,
+        g1=0.02,
+        g2=0.00,
+        psf=psf,
+        dither=True,
+        rotate=True,
+    )
 
 
 @pytest.mark.parametrize('epochs_per_band', [1, 2, 3])

--- a/descwl_shear_sims/tests/test_trivial_sim.py
+++ b/descwl_shear_sims/tests/test_trivial_sim.py
@@ -11,6 +11,39 @@ from ..trivial_sim import (
 )
 
 
+def test_trivial_star_bleeds():
+    seed = 742
+    coadd_dim = 201
+    buff = 30
+    rng = np.random.RandomState(seed)
+
+    galaxy_catalog = make_galaxy_catalog(
+        rng=rng,
+        gal_type="exp",
+        coadd_dim=coadd_dim,
+        layout="grid",
+        buff=buff,
+    )
+    star_catalog = StarCatalog(
+        rng=rng,
+        coadd_dim=coadd_dim,
+        buff=buff,
+        density=100,
+    )
+
+    psf = make_psf(psf_type="gauss")
+    _ = make_trivial_sim(
+        rng=rng,
+        galaxy_catalog=galaxy_catalog,
+        star_catalog=star_catalog,
+        coadd_dim=coadd_dim,
+        g1=0.02,
+        g2=0.00,
+        psf=psf,
+        star_bleeds=True,
+    )
+
+
 @pytest.mark.parametrize('dither,rotate', [
     (False, False),
     (False, True),
@@ -258,6 +291,7 @@ def test_trivial_sim_stars():
         rng=rng,
         coadd_dim=coadd_dim,
         buff=buff,
+        density=100,
     )
 
     psf = make_psf(psf_type="moffat")

--- a/descwl_shear_sims/tests/test_trivial_sim.py
+++ b/descwl_shear_sims/tests/test_trivial_sim.py
@@ -90,7 +90,12 @@ def test_trivial_sim():
         assert band in band_data
 
 
-def test_trivial_sim_exp_mag():
+@pytest.mark.parametrize("rotate", [False, True])
+def test_trivial_sim_exp_mag(rotate):
+    """
+    test we get the right mag.  Also test we get small flux when we rotate and
+    there is nothing at the sub image location we choose
+    """
 
     bands = ["i"]
     seed = 8123
@@ -114,13 +119,19 @@ def test_trivial_sim_exp_mag():
         g2=0.00,
         psf=psf,
         bands=bands,
+        rotate=rotate,
     )
 
     image = sim_data["band_data"]["i"][0].image.array
-    subim = image[105:130, 100:125]
-    mag = ZERO_POINT - 2.5*np.log10(subim.sum())
+    subim_sum = image[105:130, 100:125].sum()
 
-    assert abs(mag - DEFAULT_FIXED_GAL_CONFIG['mag']) < 0.005
+    if rotate:
+        # we expect nothing there
+        assert abs(subim_sum) < 30
+    else:
+        # we expect something there with about the right magnitude
+        mag = ZERO_POINT - 2.5*np.log10(subim_sum)
+        assert abs(mag - DEFAULT_FIXED_GAL_CONFIG['mag']) < 0.005
 
 
 @pytest.mark.parametrize("psf_type", ["gauss", "moffat", "ps"])

--- a/descwl_shear_sims/tests/test_trivial_sim.py
+++ b/descwl_shear_sims/tests/test_trivial_sim.py
@@ -4,6 +4,7 @@ import numpy as np
 from ..trivial_sim import (
     make_trivial_sim,
     make_galaxy_catalog,
+    make_psf,
 )
 
 
@@ -27,12 +28,14 @@ def test_trivial_sim_smoke(dither, rotate):
         layout="grid",
     )
 
+    psf = make_psf(psf_type="gauss")
     _ = make_trivial_sim(
         rng=rng,
         galaxy_catalog=galaxy_catalog,
         coadd_dim=351,
         g1=0.02,
         g2=0.00,
+        psf=psf,
         dither=dither,
         rotate=rotate,
     )
@@ -54,6 +57,7 @@ def test_trivial_sim():
         layout="grid",
     )
 
+    psf = make_psf(psf_type="moffat")
     sim_data = make_trivial_sim(
         rng=rng,
         galaxy_catalog=galaxy_catalog,
@@ -61,6 +65,7 @@ def test_trivial_sim():
         psf_dim=psf_dim,
         g1=0.02,
         g2=0.00,
+        psf=psf,
         bands=bands,
     )
 
@@ -92,6 +97,7 @@ def test_trivial_sim_epochs(epochs_per_band):
         layout="grid",
     )
 
+    psf = make_psf(psf_type="gauss")
     sim_data = make_trivial_sim(
         rng=rng,
         galaxy_catalog=galaxy_catalog,
@@ -99,6 +105,7 @@ def test_trivial_sim_epochs(epochs_per_band):
         psf_dim=psf_dim,
         g1=0.02,
         g2=0.00,
+        psf=psf,
         bands=bands,
         epochs_per_band=epochs_per_band,
     )
@@ -123,12 +130,14 @@ def test_trivial_sim_layout(layout):
         layout=layout,
     )
 
+    psf = make_psf(psf_type="gauss")
     _ = make_trivial_sim(
         rng=rng,
         galaxy_catalog=galaxy_catalog,
         coadd_dim=coadd_dim,
         g1=0.02,
         g2=0.00,
+        psf=psf,
     )
 
 
@@ -148,10 +157,12 @@ def test_trivial_sim_wldeblend():
         buff=30,
     )
 
+    psf = make_psf(psf_type="moffat")
     _ = make_trivial_sim(
         rng=rng,
         galaxy_catalog=galaxy_catalog,
         coadd_dim=coadd_dim,
         g1=0.02,
         g2=0.00,
+        psf=psf,
     )

--- a/descwl_shear_sims/tests/test_trivial_sim.py
+++ b/descwl_shear_sims/tests/test_trivial_sim.py
@@ -11,39 +11,6 @@ from ..trivial_sim import (
 )
 
 
-def test_trivial_star_bleeds():
-    seed = 742
-    coadd_dim = 201
-    buff = 30
-    rng = np.random.RandomState(seed)
-
-    galaxy_catalog = make_galaxy_catalog(
-        rng=rng,
-        gal_type="exp",
-        coadd_dim=coadd_dim,
-        layout="grid",
-        buff=buff,
-    )
-    star_catalog = StarCatalog(
-        rng=rng,
-        coadd_dim=coadd_dim,
-        buff=buff,
-        density=100,
-    )
-
-    psf = make_psf(psf_type="gauss")
-    _ = make_trivial_sim(
-        rng=rng,
-        galaxy_catalog=galaxy_catalog,
-        star_catalog=star_catalog,
-        coadd_dim=coadd_dim,
-        g1=0.02,
-        g2=0.00,
-        psf=psf,
-        star_bleeds=True,
-    )
-
-
 @pytest.mark.parametrize('dither,rotate', [
     (False, False),
     (False, True),

--- a/descwl_shear_sims/tests/test_trivial_sim.py
+++ b/descwl_shear_sims/tests/test_trivial_sim.py
@@ -4,6 +4,7 @@ import numpy as np
 from ..trivial_sim import (
     make_trivial_sim,
     make_galaxy_catalog,
+    StarCatalog,
     make_psf,
     make_ps_psf,
     get_se_dim,
@@ -196,6 +197,40 @@ def test_trivial_sim_wldeblend():
     _ = make_trivial_sim(
         rng=rng,
         galaxy_catalog=galaxy_catalog,
+        coadd_dim=coadd_dim,
+        g1=0.02,
+        g2=0.00,
+        psf=psf,
+    )
+
+@pytest.mark.skipif(
+    "CATSIM_DIR" not in os.environ,
+    reason='simulation input data is not present',
+)
+def test_trivial_sim_stars():
+    seed = 7421
+    coadd_dim = 201
+    buff = 30
+    rng = np.random.RandomState(seed)
+
+    galaxy_catalog = make_galaxy_catalog(
+        rng=rng,
+        gal_type="wldeblend",
+        coadd_dim=coadd_dim,
+        buff=buff,
+    )
+
+    star_catalog = StarCatalog(
+        rng=rng,
+        coadd_dim=coadd_dim,
+        buff=buff,
+    )
+
+    psf = make_psf(psf_type="moffat")
+    _ = make_trivial_sim(
+        rng=rng,
+        galaxy_catalog=galaxy_catalog,
+        star_catalog=star_catalog,
         coadd_dim=coadd_dim,
         g1=0.02,
         g2=0.00,

--- a/descwl_shear_sims/tests/test_trivial_sim.py
+++ b/descwl_shear_sims/tests/test_trivial_sim.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from ..trivial_sim import TrivialSim
+from ..trivial_sim import make_trivial_sim
 
 
 @pytest.mark.parametrize('dither,rotate', [
@@ -12,20 +12,47 @@ from ..trivial_sim import TrivialSim
 def test_trivial_sim_smoke(dither, rotate):
 
     seed = 74321
-    noise = 0.001
-    g1 = 0.02
-    g2 = 0.0
     rng = np.random.RandomState(seed)
-    sim = TrivialSim(
+    _ = make_trivial_sim(
         rng=rng,
-        noise=noise,
-        g1=g1,
-        g2=g2,
+        noise=0.001,
+        coadd_dim=351,
+        buff=50,
+        layout='grid',
+        g1=0.02,
+        g2=0.00,
         dither=dither,
         rotate=rotate,
     )
 
-    _ = sim.gen_sim()
+
+def test_trivial_sim():
+
+    bands = ["i"]
+    seed = 7421
+    coadd_dim = 201
+    psf_dim = 47
+    rng = np.random.RandomState(seed)
+    sim_data = make_trivial_sim(
+        rng=rng,
+        noise=0.001,
+        coadd_dim=coadd_dim,
+        buff=3,
+        psf_dim=psf_dim,
+        layout="grid",
+        g1=0.02,
+        g2=0.00,
+        bands=bands,
+    )
+
+    assert 'coadd_dims' in sim_data
+    assert sim_data['coadd_dims'] == [coadd_dim]*2
+    assert 'psf_dims' in sim_data
+    assert sim_data['psf_dims'] == [psf_dim]*2
+
+    band_data = sim_data['band_data']
+    for band in bands:
+        assert band in band_data
 
 
 @pytest.mark.parametrize('epochs_per_band', [1, 2, 3])
@@ -33,22 +60,43 @@ def test_trivial_sim_epochs(epochs_per_band):
 
     bands = ['r', 'i', 'z']
     seed = 7421
-    noise = 0.001
-    g1 = 0.02
-    g2 = 0.0
+    coadd_dim = 301
+    psf_dim = 47
     rng = np.random.RandomState(seed)
-    sim = TrivialSim(
+    sim_data = make_trivial_sim(
         rng=rng,
-        noise=noise,
-        g1=g1,
-        g2=g2,
+        noise=0.001,
+        coadd_dim=coadd_dim,
+        buff=10,
+        psf_dim=psf_dim,
+        layout='grid',
+        g1=0.02,
+        g2=0.00,
         dither=True,
         rotate=True,
         bands=bands,
         epochs_per_band=epochs_per_band,
     )
-    data = sim.gen_sim()
 
+    band_data = sim_data['band_data']
     for band in bands:
-        assert band in data
-        assert len(data[band]) == epochs_per_band
+        assert band in band_data
+        assert len(band_data[band]) == epochs_per_band
+
+
+@pytest.mark.parametrize("layout", ("grid", "random"))
+def test_trivial_sim_layout(layout):
+
+    seed = 812
+    psf_dim = 47
+    rng = np.random.RandomState(seed)
+    _ = make_trivial_sim(
+        rng=rng,
+        noise=0.001,
+        coadd_dim=351,
+        buff=10,
+        psf_dim=psf_dim,
+        layout=layout,
+        g1=0.02,
+        g2=0.00,
+    )

--- a/descwl_shear_sims/tests/test_trivial_sim.py
+++ b/descwl_shear_sims/tests/test_trivial_sim.py
@@ -177,8 +177,14 @@ def test_trivial_sim_layout(layout):
     )
 
 
-@pytest.mark.parametrize("cosmic_rays", (True, False))
-def test_trivial_sim_cosmic_rays(cosmic_rays):
+@pytest.mark.parametrize(
+    "cosmic_rays, bad_columns",
+    [(True, True),
+     (True, False),
+     (False, True),
+     (True, True)],
+)
+def test_trivial_sim_defects(cosmic_rays, bad_columns):
     seed = 7421
     coadd_dim = 201
     rng = np.random.RandomState(seed)
@@ -200,31 +206,6 @@ def test_trivial_sim_cosmic_rays(cosmic_rays):
         g2=0.00,
         psf=psf,
         cosmic_rays=cosmic_rays,
-    )
-
-
-@pytest.mark.parametrize("bad_columns", (True, False))
-def test_trivial_sim_bad_columns(bad_columns):
-    seed = 7421
-    coadd_dim = 201
-    rng = np.random.RandomState(seed)
-
-    galaxy_catalog = make_galaxy_catalog(
-        rng=rng,
-        gal_type="exp",
-        coadd_dim=coadd_dim,
-        layout="grid",
-        buff=30,
-    )
-
-    psf = make_psf(psf_type="gauss")
-    _ = make_trivial_sim(
-        rng=rng,
-        galaxy_catalog=galaxy_catalog,
-        coadd_dim=coadd_dim,
-        g1=0.02,
-        g2=0.00,
-        psf=psf,
         bad_columns=bad_columns,
     )
 

--- a/descwl_shear_sims/tests/test_trivial_sim.py
+++ b/descwl_shear_sims/tests/test_trivial_sim.py
@@ -1,6 +1,9 @@
 import pytest
 import numpy as np
-from ..trivial_sim import make_trivial_sim
+from ..trivial_sim import (
+    make_trivial_sim,
+    make_galaxy_catalog,
+)
 
 
 @pytest.mark.parametrize('dither,rotate', [
@@ -13,12 +16,20 @@ def test_trivial_sim_smoke(dither, rotate):
 
     seed = 74321
     rng = np.random.RandomState(seed)
+
+    coadd_dim = 341
+    galaxy_catalog = make_galaxy_catalog(
+        rng=rng,
+        gal_type="exp",
+        coadd_dim=coadd_dim,
+        buff=30,
+        layout="grid",
+    )
+
     _ = make_trivial_sim(
         rng=rng,
-        noise=0.001,
+        galaxy_catalog=galaxy_catalog,
         coadd_dim=351,
-        buff=50,
-        layout='grid',
         g1=0.02,
         g2=0.00,
         dither=dither,
@@ -33,13 +44,20 @@ def test_trivial_sim():
     coadd_dim = 201
     psf_dim = 47
     rng = np.random.RandomState(seed)
+
+    galaxy_catalog = make_galaxy_catalog(
+        rng=rng,
+        gal_type="exp",
+        coadd_dim=coadd_dim,
+        buff=30,
+        layout="grid",
+    )
+
     sim_data = make_trivial_sim(
         rng=rng,
-        noise=0.001,
+        galaxy_catalog=galaxy_catalog,
         coadd_dim=coadd_dim,
-        buff=3,
         psf_dim=psf_dim,
-        layout="grid",
         g1=0.02,
         g2=0.00,
         bands=bands,
@@ -58,22 +76,28 @@ def test_trivial_sim():
 @pytest.mark.parametrize('epochs_per_band', [1, 2, 3])
 def test_trivial_sim_epochs(epochs_per_band):
 
-    bands = ['r', 'i', 'z']
     seed = 7421
+    bands = ["r", "i", "z"]
     coadd_dim = 301
     psf_dim = 47
+
     rng = np.random.RandomState(seed)
-    sim_data = make_trivial_sim(
+
+    galaxy_catalog = make_galaxy_catalog(
         rng=rng,
-        noise=0.001,
+        gal_type="exp",
         coadd_dim=coadd_dim,
         buff=10,
+        layout="grid",
+    )
+
+    sim_data = make_trivial_sim(
+        rng=rng,
+        galaxy_catalog=galaxy_catalog,
+        coadd_dim=coadd_dim,
         psf_dim=psf_dim,
-        layout='grid',
         g1=0.02,
         g2=0.00,
-        dither=True,
-        rotate=True,
         bands=bands,
         epochs_per_band=epochs_per_band,
     )
@@ -86,17 +110,22 @@ def test_trivial_sim_epochs(epochs_per_band):
 
 @pytest.mark.parametrize("layout", ("grid", "random"))
 def test_trivial_sim_layout(layout):
-
-    seed = 812
-    psf_dim = 47
+    seed = 7421
+    coadd_dim = 201
     rng = np.random.RandomState(seed)
+
+    galaxy_catalog = make_galaxy_catalog(
+        rng=rng,
+        gal_type="exp",
+        coadd_dim=coadd_dim,
+        buff=30,
+        layout=layout,
+    )
+
     _ = make_trivial_sim(
         rng=rng,
-        noise=0.001,
-        coadd_dim=351,
-        buff=10,
-        psf_dim=psf_dim,
-        layout=layout,
+        galaxy_catalog=galaxy_catalog,
+        coadd_dim=coadd_dim,
         g1=0.02,
         g2=0.00,
     )

--- a/descwl_shear_sims/tests/test_trivial_sim.py
+++ b/descwl_shear_sims/tests/test_trivial_sim.py
@@ -177,6 +177,58 @@ def test_trivial_sim_layout(layout):
     )
 
 
+@pytest.mark.parametrize("cosmic_rays", (True, False))
+def test_trivial_sim_cosmic_rays(cosmic_rays):
+    seed = 7421
+    coadd_dim = 201
+    rng = np.random.RandomState(seed)
+
+    galaxy_catalog = make_galaxy_catalog(
+        rng=rng,
+        gal_type="exp",
+        coadd_dim=coadd_dim,
+        layout="grid",
+        buff=30,
+    )
+
+    psf = make_psf(psf_type="gauss")
+    _ = make_trivial_sim(
+        rng=rng,
+        galaxy_catalog=galaxy_catalog,
+        coadd_dim=coadd_dim,
+        g1=0.02,
+        g2=0.00,
+        psf=psf,
+        cosmic_rays=cosmic_rays,
+    )
+
+
+@pytest.mark.parametrize("bad_columns", (True, False))
+def test_trivial_sim_bad_columns(bad_columns):
+    seed = 7421
+    coadd_dim = 201
+    rng = np.random.RandomState(seed)
+
+    galaxy_catalog = make_galaxy_catalog(
+        rng=rng,
+        gal_type="exp",
+        coadd_dim=coadd_dim,
+        layout="grid",
+        buff=30,
+    )
+
+    psf = make_psf(psf_type="gauss")
+    _ = make_trivial_sim(
+        rng=rng,
+        galaxy_catalog=galaxy_catalog,
+        coadd_dim=coadd_dim,
+        g1=0.02,
+        g2=0.00,
+        psf=psf,
+        bad_columns=bad_columns,
+    )
+
+
 @pytest.mark.skipif(
     "CATSIM_DIR" not in os.environ,
     reason='simulation input data is not present',

--- a/descwl_shear_sims/tests/test_trivial_sim.py
+++ b/descwl_shear_sims/tests/test_trivial_sim.py
@@ -304,3 +304,40 @@ def test_trivial_sim_stars():
         g2=0.00,
         psf=psf,
     )
+
+
+@pytest.mark.skipif(
+    "CATSIM_DIR" not in os.environ,
+    reason='simulation input data is not present',
+)
+def test_trivial_sim_star_bleeds():
+    seed = 7421
+    coadd_dim = 201
+    buff = 30
+    rng = np.random.RandomState(seed)
+
+    galaxy_catalog = make_galaxy_catalog(
+        rng=rng,
+        gal_type="wldeblend",
+        coadd_dim=coadd_dim,
+        buff=buff,
+    )
+
+    star_catalog = StarCatalog(
+        rng=rng,
+        coadd_dim=coadd_dim,
+        buff=buff,
+        density=100,
+    )
+
+    psf = make_psf(psf_type="moffat")
+    _ = make_trivial_sim(
+        rng=rng,
+        galaxy_catalog=galaxy_catalog,
+        star_catalog=star_catalog,
+        coadd_dim=coadd_dim,
+        g1=0.02,
+        g2=0.00,
+        psf=psf,
+        star_bleeds=True,
+    )

--- a/descwl_shear_sims/trivial_sim.py
+++ b/descwl_shear_sims/trivial_sim.py
@@ -28,6 +28,7 @@ DEFAULT_TRIVIAL_SIM_CONFIG = {
     "rotate": False,
     "bands": ["i"],
     "epochs_per_band": 1,
+    "noise_factor": 1.0,
 }
 
 DEFAULT_FIXED_GAL_CONFIG = {
@@ -49,6 +50,7 @@ def make_trivial_sim(
     rotate=False,
     bands=['i'],
     epochs_per_band=1,
+    noise_factor=1.0,
 ):
     """
     Make simulation data
@@ -57,13 +59,26 @@ def make_trivial_sim(
     ----------
     rng: numpy.random.RandomState
         Numpy random state
+    galaxy_catalog: catalog
+        E.g. WLDeblendGalaxyCatalog or FixedGalaxyCatalog
     coadd_dim: int
         Default 351
     g1: float
         Shear g1 for galaxies
     g2: float
         Shear g2 for galaxies
-
+    psf_dim: int, optional
+        Dimensions of psf image.  Default 51
+    dither: bool, optional
+        Whether to dither the images at the pixel level, default False
+    rotate: bool, optional
+        Whether to rotate the images randomly, default False
+    bands: list, optional
+        Default ['i']
+    epochs_per_band: int, optional
+        Number of epochs per band
+    noise_factor: float, optional
+        Factor by which to multiply the noise, default 1
     """
 
     se_dim = (
@@ -74,7 +89,7 @@ def make_trivial_sim(
     for band in bands:
 
         survey = get_survey(gal_type=galaxy_catalog.gal_type, band=band)
-        noise_per_epoch = survey.noise*np.sqrt(epochs_per_band)
+        noise_per_epoch = survey.noise*np.sqrt(epochs_per_band)*noise_factor
 
         all_obj = galaxy_catalog.get_all_obj(survey=survey, g1=g1, g2=g2)
 

--- a/descwl_shear_sims/trivial_sim.py
+++ b/descwl_shear_sims/trivial_sim.py
@@ -105,44 +105,6 @@ def make_trivial_sim(
     }
 
 
-def make_galaxy_catalog(
-    *,
-    rng,
-    coadd_dim=351,
-    buff=50,
-    layout='grid',
-    g1=0.0,
-    g2=0.0,
-):
-    """
-    Make an object catalog
-
-    Parameters
-    ----------
-    rng: numpy.random.RandomState
-        Numpy random state
-    coadd_dim: int
-        Default 351
-    buff: int
-        Buffer region where no objects will be drawn, default 50
-    layout: string
-        'grid' or 'random'
-    g1: float
-        Shear g1 for galaxies
-    g2: float
-        Shear g2 for galaxies
-    """
-
-    offsets = get_offsets(
-        rng=rng,
-        coadd_dim=coadd_dim,
-        buff=buff,
-        layout=layout,
-    )
-
-    return FixedGalaxyCatalog(offsets=offsets, g1=g1, g2=g2)
-
-
 class FixedGalaxyCatalog(object):
     """
     Galaxies of fixed galsim type, flux, and size
@@ -256,6 +218,8 @@ def get_offsets(
             buff=buff,
             size=nobj,
         )
+    else:
+        raise ValueError("bad layout: '%s'" % layout)
 
     return offsets
 

--- a/descwl_shear_sims/trivial_sim.py
+++ b/descwl_shear_sims/trivial_sim.py
@@ -639,7 +639,7 @@ def get_mask(*, image, rng, cosmic_rays, bad_columns):
         c_mask = generate_cosmic_rays(
             shape=shape,
             rng=rng,
-            mean_cosmic_rays=10,
+            mean_cosmic_rays=1,
         )
         mask[c_mask] |= COSMIC_RAY + SAT
 
@@ -651,7 +651,7 @@ def get_mask(*, image, rng, cosmic_rays, bad_columns):
         bc_msk = generate_bad_columns(
             shape=shape,
             rng=rng,
-            mean_bad_cols=10,
+            mean_bad_cols=1,
         )
         mask[bc_msk] |= BAD_COLUMN
         image.array[bc_msk] = 0.0

--- a/descwl_shear_sims/trivial_sim.py
+++ b/descwl_shear_sims/trivial_sim.py
@@ -1027,7 +1027,7 @@ class StarCatalog(object):
         self._star_cat = load_sample_stars()
         density_mean = sample_star_density(
             rng=self.rng,
-            min_density=99,
+            min_density=2,
             max_density=100,
         )
 

--- a/descwl_shear_sims/trivial_sim.py
+++ b/descwl_shear_sims/trivial_sim.py
@@ -6,6 +6,8 @@ import descwl
 from .se_obs import SEObs
 from .cache_tools import cached_catalog_read
 
+PSF_FWHM = 0.8
+MOFFAT_BETA = 2.5
 SCALE = 0.2
 WORLD_ORIGIN = galsim.CelestialCoord(
     ra=200 * galsim.degrees,
@@ -16,20 +18,21 @@ GRID_N_ON_SIDE = 6
 RANDOM_DENSITY = 80  # per square arcmin
 
 DEFAULT_TRIVIAL_SIM_CONFIG = {
-    'gal_type': 'exp',
-    'psf_dim': 51,
-    'coadd_dim': 351,
-    'buff': 50,
-    'layout': 'grid',
-    'dither': False,
-    'rotate': False,
-    'bands': ['i'],
-    'epochs_per_band': 1,
+    "gal_type": "exp",
+    "psf_type": "gauss",
+    "psf_dim": 51,
+    "coadd_dim": 351,
+    "buff": 50,
+    "layout": "grid",
+    "dither": False,
+    "rotate": False,
+    "bands": ["i"],
+    "epochs_per_band": 1,
 }
 
 DEFAULT_FIXED_GAL_CONFIG = {
-    'flux': 150000.0,
-    'hlr': 0.5,
+    "flux": 150000.0,
+    "hlr": 0.5,
 }
 
 
@@ -40,6 +43,7 @@ def make_trivial_sim(
     coadd_dim,
     g1,
     g2,
+    psf,
     psf_dim=51,
     dither=False,
     rotate=False,
@@ -61,8 +65,6 @@ def make_trivial_sim(
         Shear g2 for galaxies
 
     """
-
-    psf = galsim.Gaussian(fwhm=0.8)
 
     se_dim = (
         int(np.ceil(coadd_dim * np.sqrt(2))) + 20
@@ -661,3 +663,14 @@ def read_wldeblend_cat(rng):
     )
     cat['pa_bulge'] = cat['pa_disk']
     return cat
+
+
+def make_psf(*, psf_type):
+    if psf_type == "gauss":
+        psf = galsim.Gaussian(fwhm=PSF_FWHM)
+    elif psf_type == "moffat":
+        psf = galsim.Moffat(fwhm=PSF_FWHM, beta=MOFFAT_BETA)
+    else:
+        raise ValueError("bad psf_type '%s'" % psf_type)
+
+    return psf

--- a/descwl_shear_sims/trivial_sim.py
+++ b/descwl_shear_sims/trivial_sim.py
@@ -9,222 +9,178 @@ WORLD_ORIGIN = galsim.CelestialCoord(
     dec=0 * galsim.degrees,
 )
 
+GRID_N_ON_SIDE = 6
+RANDOM_DENSITY = 80  # per square arcmin
 
-class TrivialSim(object):
+DEFAULT_TRIVIAL_SIM_CONFIG = {
+    'psf_dim': 51,
+    'coadd_dim': 351,
+    'buff': 50,
+    'layout': 'grid',
+    'dither': False,
+    'rotate': False,
+    'bands': ['i'],
+    'epochs_per_band': 1,
+}
+
+
+def make_trivial_sim(
+    *,
+    rng,
+    noise,
+    coadd_dim,
+    buff,
+    layout,
+    g1,
+    g2,
+    psf_dim=51,
+    dither=False,
+    rotate=False,
+    bands=['i'],
+    epochs_per_band=1,
+):
     """
-    simple sim with round galaxies on a grid, with dithers, rotations, possibly
-    multiple epochs
+    Make simulation data
 
     Parameters
     ----------
-    rng: np.RandomState
-        The input random state
+    rng: numpy.random.RandomState
+        Numpy random state
     noise: float
-        Noise level.  If there are multiple epochs, the noise per epoch is set
-        to noise*sqrt(nepochs) to keep s/n constant
+        Noise level for images
+    coadd_dim: int
+        Default 351
+    buff: int
+        Buffer region where no objects will be drawn, default 50
+    layout: string
+        'grid' or 'random'
     g1: float
-        Shear g1
+        Shear g1 for galaxies
     g2: float
-        Shear g2
-    dither: bool
-        If True, dither the images by +/- 0.5 pixels, default False
-    rotate: bool
-        If True, rotate randomly, default False
-    bands: sequence
-        List of band names, default ['i']
-    epochs_per_band: int
-        Number of epochs per band, default 1
-    """
-    def __init__(self,
-                 *, rng, noise, g1, g2,
-                 dither=False, rotate=False,
-                 bands=['i'], epochs_per_band=1):
+        Shear g2 for galaxies
 
-        self.rng = rng
-        self.psf_dim = 51
-        self.coadd_dim = 351
+    """
+    offsets = get_offsets(
+        rng=rng,
+        coadd_dim=coadd_dim,
+        buff=buff,
+        layout=layout,
+    )
+
+    galaxy_catalog = FixedGalaxyCatalog(offsets=offsets, g1=g1, g2=g2)
+    psf = galsim.Gaussian(fwhm=0.8)
+
+    noise_per_epoch = noise*np.sqrt(epochs_per_band)
+
+    se_dim = (
+        int(np.ceil(coadd_dim * np.sqrt(2))) + 20
+    )
+
+    band_data = {}
+    for band in bands:
+        all_obj = galaxy_catalog.get_objects(band=band)
+        seobj_list = []
+        for epoch in range(epochs_per_band):
+            seobs = make_seobs(
+                rng=rng,
+                noise=noise_per_epoch,
+                all_obj=all_obj,
+                dim=se_dim,
+                psf=psf,
+                psf_dim=psf_dim,
+                dither=dither,
+                rotate=rotate,
+            )
+            seobj_list.append(seobs)
+
+        band_data[band] = seobj_list
+
+    coadd_wcs = make_coadd_wcs(coadd_dim)
+
+    return {
+        'band_data': band_data,
+        'coadd_wcs': coadd_wcs,
+        'psf_dims': [psf_dim]*2,
+        'coadd_dims': [coadd_dim]*2,
+    }
+
+
+def make_galaxy_catalog(
+    *,
+    rng,
+    coadd_dim=351,
+    buff=50,
+    layout='grid',
+    g1=0.0,
+    g2=0.0,
+):
+    """
+    Make an object catalog
+
+    Parameters
+    ----------
+    rng: numpy.random.RandomState
+        Numpy random state
+    coadd_dim: int
+        Default 351
+    buff: int
+        Buffer region where no objects will be drawn, default 50
+    layout: string
+        'grid' or 'random'
+    g1: float
+        Shear g1 for galaxies
+    g2: float
+        Shear g2 for galaxies
+    """
+
+    offsets = get_offsets(
+        rng=rng,
+        coadd_dim=coadd_dim,
+        buff=buff,
+        layout=layout,
+    )
+
+    return FixedGalaxyCatalog(offsets=offsets, g1=g1, g2=g2)
+
+
+class FixedGalaxyCatalog(object):
+    """
+    Galaxies of fixed galsim type, flux, and size
+
+    Same for all bands
+    """
+    def __init__(self, *, offsets, g1, g2):
+        self.offsets = offsets
         self.g1 = g1
         self.g2 = g2
-        self.object_data = None
-        noise_per_epoch = noise*np.sqrt(epochs_per_band)
 
-        all_obj = self.get_objects()
+    def get_objects(self, *, band):
+        """
+        get a list of galsim objects
 
-        se_dim = (
-            int(np.ceil(self.coadd_dim * np.sqrt(2))) + 20
-        )
+        Parameters
+        ----------
+        band: string
+            Get objects for this band.  For the fixed
+            catalog, the objects are the same for every band
 
-        self._sim_data = {}
-        for band in bands:
-            se_obslist = []
-            for epoch in range(epochs_per_band):
-                tim = TrivialImage(
-                    rng=rng,
-                    noise=noise_per_epoch,
-                    all_obj=all_obj,
-                    dim=se_dim,
-                    psf_dim=self.psf_dim,
-                    dither=dither,
-                    rotate=rotate,
-                )
-                se_obslist.append(tim.seobs)
-
-            self._sim_data[band] = se_obslist
-
-        self._set_coadd_wcs()
-
-    def get_objects(self):
-
-        n_on_side = 6
-        spacing = self.coadd_dim/(n_on_side+1)*SCALE
-
-        # ix/iy are really on the sky
-        grid = spacing*(np.arange(n_on_side) - (n_on_side-1)/2)
-
+        Returns
+        -------
+        list of galsim objects
+        """
         objlist = []
-        for ix in range(n_on_side):
-            for iy in range(n_on_side):
-                dx = grid[ix] + SCALE*self.rng.uniform(low=-0.5, high=0.5)
-                dy = grid[iy] + SCALE*self.rng.uniform(low=-0.5, high=0.5)
-
-                obj = galsim.Exponential(
-                    half_light_radius=0.5,
-                ).shift(
-                    dx=dx,
-                    dy=dy,
-                )
-                objlist.append(obj)
+        for i in range(self.offsets.size):
+            obj = galsim.Exponential(
+                half_light_radius=0.5,
+            ).shift(
+                dx=self.offsets['dx'][i],
+                dy=self.offsets['dy'][i]
+            )
+            objlist.append(obj)
 
         all_obj = galsim.Add(objlist)
         all_obj = all_obj.shear(g1=self.g1, g2=self.g2)
         return all_obj
-
-    def gen_sim(self):
-        """
-        Returns a dict, keyed by band, with values lists
-        of SEObs.  Currently the band is always 'i' and the
-        lists are length 1
-        """
-        return self._sim_data
-
-    def _set_coadd_wcs(self):
-        # the coadd will be placed on the undithered grid
-        coadd_dims = [self.coadd_dim]*2
-        coadd_cen = (np.array(coadd_dims)-1)/2
-        coadd_origin = galsim.PositionD(x=coadd_cen[1], y=coadd_cen[0])
-        self.coadd_wcs = make_wcs(
-            scale=SCALE,
-            image_origin=coadd_origin,
-            world_origin=WORLD_ORIGIN,
-        )
-
-
-class TrivialImage(object):
-    def __init__(self, *, rng, noise, all_obj, dim,
-                 psf_dim,
-                 dither=False, rotate=False):
-        """
-        make a grid sim with trivial pixel scale, fixed sized
-        exponentials and gaussian psf
-
-        Parameters
-        ----------
-        rng: numpy.RandomState
-            The random number generator
-        noise: float
-            Gaussian noise level
-        g1: float
-            Shear g1
-        g2: float
-            Shear g2
-        dither: bool
-            If set to True, dither randomly by a pixel width
-        rotate: bool
-            If set to True, rotate the image randomly
-        """
-
-        self.psf_dim = psf_dim
-
-        self._psf = galsim.Gaussian(fwhm=0.8)
-
-        dims = [dim]*2
-        cen = (np.array(dims)-1)/2
-
-        se_origin = galsim.PositionD(x=cen[1], y=cen[0])
-        if dither:
-            dither_range = 0.5
-            off = rng.uniform(low=-dither_range, high=dither_range, size=2)
-            self._offset = galsim.PositionD(x=off[0], y=off[1])
-            se_origin = se_origin + self._offset
-        else:
-            self._offset = None
-
-        if rotate:
-            theta = rng.uniform(low=0, high=2*np.pi)
-        else:
-            theta = None
-
-        self.se_wcs = make_wcs(
-            scale=SCALE,
-            theta=theta,
-            image_origin=se_origin,
-            world_origin=WORLD_ORIGIN,
-        )
-
-        # we want to fit them into the coadd region
-        convolved_obj = galsim.Convolve(all_obj, self._psf)
-
-        # everything gets shifted by the dither offset
-        image = convolved_obj.drawImage(
-            nx=dim,
-            ny=dim,
-            wcs=self.se_wcs,
-            offset=self._offset,
-        )
-        weight = image.copy()
-        weight.array[:, :] = 1.0/noise**2
-
-        image.array[:, :] += rng.normal(scale=noise, size=dims)
-        noise_image = image.copy()
-        noise_image.array[:, :] = rng.normal(scale=noise, size=dims)
-
-        bmask = galsim.Image(
-            np.zeros(dims, dtype='i4'),
-            bounds=image.bounds,
-            wcs=image.wcs,
-            dtype=np.int32,
-        )
-
-        self.seobs = SEObs(
-            image=image,
-            noise=noise_image,
-            weight=weight,
-            wcs=self.se_wcs,
-            psf_function=self._psf_func,
-            bmask=bmask,
-        )
-
-    def _psf_func(self, *, x, y, center_psf, get_offset=False):
-        """
-        center_psf is ignored
-        """
-        image_pos = galsim.PositionD(x=x, y=y)
-
-        offset = copy.deepcopy(self._offset)
-
-        if center_psf:
-            print("ignoring request to center psf, using internal offset")
-
-        gsimage = self._psf.drawImage(
-            nx=self.psf_dim,
-            ny=self.psf_dim,
-            offset=offset,
-            wcs=self.se_wcs.local(image_pos=image_pos),
-        )
-        if get_offset:
-            return gsimage, offset
-        else:
-            return gsimage
 
 
 def make_wcs(*, scale, image_origin, world_origin, theta=None):
@@ -250,3 +206,258 @@ def make_wcs(*, scale, image_origin, world_origin, theta=None):
         world_origin=world_origin,
         units=galsim.arcsec,
     )
+
+
+def make_coadd_wcs(coadd_dim):
+    coadd_dims = [coadd_dim]*2
+    coadd_cen = (np.array(coadd_dims)-1)/2
+    coadd_origin = galsim.PositionD(x=coadd_cen[1], y=coadd_cen[0])
+    return make_wcs(
+        scale=SCALE,
+        image_origin=coadd_origin,
+        world_origin=WORLD_ORIGIN,
+    )
+
+
+def get_offsets(
+    *,
+    rng,
+    coadd_dim,
+    buff,
+    layout,
+):
+    """
+    make position offsets for objects
+
+    rng: numpy.random.RandomState
+        Numpy random state
+    coadd_dim: int
+        Dimensions of final coadd
+    buff: int
+        Buffer region where no objects will be drawn
+    layout: string
+        'grid' or 'random'
+    """
+
+    if layout == 'grid':
+        offsets = get_grid_offsets(
+            rng=rng,
+            dim=coadd_dim,
+            n_on_side=GRID_N_ON_SIDE,
+        )
+    elif layout == 'random':
+        # area covered by objects
+        area = ((coadd_dim - 2*buff)*SCALE/60)**2
+        nobj_mean = area * RANDOM_DENSITY
+        nobj = rng.poisson(nobj_mean)
+        offsets = get_random_offsets(
+            rng=rng,
+            dim=coadd_dim,
+            buff=buff,
+            size=nobj,
+        )
+
+    return offsets
+
+
+def get_grid_offsets(*, rng, dim, n_on_side):
+    """
+    get a set of gridded offsets, with random offsets at the pixel scale
+
+    Parameters
+    ----------
+    rng: numpy.random.RandomState
+        The random number generator
+    dim: int
+        Dimensions of the final image
+    n_on_side: int
+        Number of objects on each side
+
+    Returns
+    -------
+    offsets: array
+        Array with dx, dy offset fields for each point, in
+        arcsec
+    """
+    spacing = dim/(n_on_side+1)*SCALE
+
+    ntot = n_on_side**2
+
+    # ix/iy are really on the sky
+    grid = spacing*(np.arange(n_on_side) - (n_on_side-1)/2)
+
+    offsets = np.zeros(ntot, dtype=[('dx', 'f8'), ('dy', 'f8')])
+
+    i = 0
+    for ix in range(n_on_side):
+        for iy in range(n_on_side):
+            dx = grid[ix] + SCALE*rng.uniform(low=-0.5, high=0.5)
+            dy = grid[iy] + SCALE*rng.uniform(low=-0.5, high=0.5)
+
+            offsets['dx'][i] = dx
+            offsets['dy'][i] = dy
+            i += 1
+
+    return offsets
+
+
+def get_random_offsets(*, rng, dim, buff, size):
+    """
+    get a set of gridded offsets, with random offsets at the pixel scale
+
+    Parameters
+    ----------
+    rng: numpy.random.RandomState
+        The random number generator
+    dim: int
+        Dimensions of the final image
+    n_on_side: int
+        Number of objects on each side
+
+    Returns
+    -------
+    offsets: array
+        Array with dx, dy offset fields for each point, in
+        arcsec
+    """
+
+    halfwidth = (dim - 2*buff)/2.0
+
+    low = -halfwidth*SCALE
+    high = halfwidth*SCALE
+
+    offsets = np.zeros(size, dtype=[('dx', 'f8'), ('dy', 'f8')])
+
+    offsets['dx'] = rng.uniform(low=low, high=high, size=size)
+    offsets['dy'] = rng.uniform(low=low, high=high, size=size)
+
+    return offsets
+
+
+class FixedPSF(object):
+    def __init__(self, *, psf, offset, psf_dim, wcs):
+        self._psf = psf
+        self._offset = offset
+        self._psf_dim = psf_dim
+        self._wcs = wcs
+
+    def __call__(self, *, x, y, center_psf, get_offset=False):
+        """
+        center_psf is ignored
+        """
+        image_pos = galsim.PositionD(x=x, y=y)
+
+        offset = copy.deepcopy(self._offset)
+
+        if center_psf:
+            print("ignoring request to center psf, using internal offset")
+
+        gsimage = self._psf.drawImage(
+            nx=self._psf_dim,
+            ny=self._psf_dim,
+            offset=offset,
+            wcs=self._wcs.local(image_pos=image_pos),
+        )
+        if get_offset:
+            return gsimage, offset
+        else:
+            return gsimage
+
+
+def make_seobs(
+    *,
+    rng,
+    noise,
+    all_obj,
+    dim,
+    psf,
+    psf_dim,
+    dither=False,
+    rotate=False,
+):
+    """
+    make a grid sim with trivial pixel scale, fixed sized
+    exponentials and gaussian psf
+
+    Parameters
+    ----------
+    rng: numpy.random.RandomState
+        The random number generator
+    noise: float
+        Gaussian noise level
+    g1: float
+        Shear g1
+    g2: float
+        Shear g2
+    dither: bool
+        If set to True, dither randomly by a pixel width
+    rotate: bool
+        If set to True, rotate the image randomly
+    """
+
+    dims = [dim]*2
+    cen = (np.array(dims)-1)/2
+
+    se_origin = galsim.PositionD(x=cen[1], y=cen[0])
+    if dither:
+        dither_range = 0.5
+        off = rng.uniform(low=-dither_range, high=dither_range, size=2)
+        offset = galsim.PositionD(x=off[0], y=off[1])
+        se_origin = se_origin + offset
+    else:
+        offset = None
+
+    if rotate:
+        theta = rng.uniform(low=0, high=2*np.pi)
+    else:
+        theta = None
+
+    se_wcs = make_wcs(
+        scale=SCALE,
+        theta=theta,
+        image_origin=se_origin,
+        world_origin=WORLD_ORIGIN,
+    )
+
+    # we want to fit them into the coadd region
+    convolved_objects = galsim.Convolve(all_obj, psf)
+
+    # everything gets shifted by the dither offset
+    image = convolved_objects.drawImage(
+        nx=dim,
+        ny=dim,
+        wcs=se_wcs,
+        offset=offset,
+    )
+    weight = image.copy()
+    weight.array[:, :] = 1.0/noise**2
+
+    image.array[:, :] += rng.normal(scale=noise, size=dims)
+    noise_image = image.copy()
+    noise_image.array[:, :] = rng.normal(scale=noise, size=dims)
+
+    bmask = galsim.Image(
+        np.zeros(dims, dtype='i4'),
+        bounds=image.bounds,
+        wcs=image.wcs,
+        dtype=np.int32,
+    )
+
+    psf_obj = FixedPSF(psf=psf, offset=offset, psf_dim=psf_dim, wcs=se_wcs)
+
+    return SEObs(
+        image=image,
+        noise=noise_image,
+        weight=weight,
+        wcs=se_wcs,
+        psf_function=psf_obj,
+        bmask=bmask,
+    )
+
+
+def get_trivial_sim_config(config=None):
+    out_config = copy.deepcopy(DEFAULT_TRIVIAL_SIM_CONFIG)
+
+    if config is not None:
+        out_config.update(config)
+    return out_config

--- a/descwl_shear_sims/trivial_sim.py
+++ b/descwl_shear_sims/trivial_sim.py
@@ -344,6 +344,8 @@ class FixedPSF(object):
             wcs=self._wcs.local(image_pos=image_pos),
         )
         if get_offset:
+            if offset is None:
+                offset = galsim.PositionD(x=0.0, y=0.0)
             return gsimage, offset
         else:
             return gsimage

--- a/descwl_shear_sims/trivial_sim.py
+++ b/descwl_shear_sims/trivial_sim.py
@@ -166,9 +166,9 @@ def make_trivial_sim(
             # mark high pixels SAT and also set sat value in image for
             # any pixels already marked SAT
             saturate_image_and_mask(
-                seobs.image.array,
-                seobs.bmask.array,
-                BAND_SAT_VALS[band],
+                image=seobs.image.array,
+                bmask=seobs.bmask.array,
+                sat_val=BAND_SAT_VALS[band],
             )
 
             seobs_list.append(seobs)

--- a/descwl_shear_sims/trivial_sim.py
+++ b/descwl_shear_sims/trivial_sim.py
@@ -16,7 +16,7 @@ GRID_N_ON_SIDE = 6
 RANDOM_DENSITY = 80  # per square arcmin
 
 DEFAULT_TRIVIAL_SIM_CONFIG = {
-    'gal_type': 'fixed',
+    'gal_type': 'exp',
     'psf_dim': 51,
     'coadd_dim': 351,
     'buff': 50,
@@ -119,7 +119,7 @@ def make_galaxy_catalog(
     gal_type,
     coadd_dim,
     buff,
-    layout,
+    layout=None,
     gal_config=None,
 ):
     """
@@ -131,8 +131,9 @@ def make_galaxy_catalog(
         Dimensions of coadd
     buff: int
         Buffer around the edge where no objects are drawn
-    layout: string
-        'grid' or 'random'
+    layout: string, optional
+        'grid' or 'random'.  Ignored for gal_type "wldeblend", otherwise
+        required.
     gal_config: dict or None
         Can be sent for fixed galaxy catalog.  See DEFAULT_FIXED_GAL_CONFIG
         for defaults
@@ -142,9 +143,11 @@ def make_galaxy_catalog(
             rng=rng,
             coadd_dim=coadd_dim,
             buff=buff,
-            layout=layout,
         )
     else:
+
+        if layout is None:
+            raise ValueError("send layout= for gal_type '%s'" % gal_type)
 
         gal_config = get_fixed_gal_config(config=gal_config)
         galaxy_catalog = FixedGalaxyCatalog(
@@ -558,7 +561,7 @@ class WLDeblendGalaxyCatalog(object):
     """
     Galaxies from wldeblend
     """
-    def __init__(self, *, rng, coadd_dim, buff, layout):
+    def __init__(self, *, rng, coadd_dim, buff):
         self.gal_type = 'wldeblend'
         self.rng = rng
 
@@ -574,7 +577,7 @@ class WLDeblendGalaxyCatalog(object):
             rng=rng,
             coadd_dim=coadd_dim,
             buff=buff,
-            layout=layout,
+            layout="random",
             nobj=nobj,
         )
 


### PR DESCRIPTION
Bring trivial sim up to near feature parity with sim

Most features are there, but many of the options are not exposed.  e.g. there is an option to add stars but you don't get to choose how they are added.

The tests all pass but I don't consider that good enough for a merge, partly because more unit tests are needed.  But it is also due to a change in philosophy:

_I now only consider a feature ready if I have run it all the way to recovered shear and I understand the result_

This means waiting until a potentially long test is run, days or even weeks depending on the availability of computing resources.

TODO on this PR

- [x] finish run with stars+wldeblend+PS psf (should finish in a day or two)
- [x] run with star bleeds, cosmics, badcols, etc. (few days to run)
- [x] run with 3 bands
- [ ] add SIP wcs (maybe wait for a separate PR)
- [x] more pixel level unit tests
- [x] normalize use of name bmask rather than mask everywhere in the code
- [ ] consider whether we should try to move the objects using the full wcs and draw in postage stamps (maybe push to separate PR)

