### PR TITLE
Make deep copy of input configs

### DIFF
--- a/descwl_shear_sims/sim.py
+++ b/descwl_shear_sims/sim.py
@@ -1,4 +1,4 @@
-import copy
+from copy import deepcopy
 import esutil as eu
 import galsim
 import numpy as np
@@ -578,14 +578,16 @@ def get_sim_config(config=None):
     -------
     config dict
     """
-    out_config = copy.deepcopy(DEFAULT_SIM_CONFIG)
+    out_config = deepcopy(DEFAULT_SIM_CONFIG)
     sub_configs = ['gal_config', 'star_config']
 
     if config is not None:
         for key in config:
             if key not in out_config and key not in sub_configs:
                 raise ValueError("bad key for sim: '%s'" % key)
-        out_config.update(config)
+
+        out_config.update(deepcopy(config))
+
     return out_config
 
 

--- a/descwl_shear_sims/tests/test_config.py
+++ b/descwl_shear_sims/tests/test_config.py
@@ -1,0 +1,30 @@
+import pytest
+
+from descwl_shear_sims.sim import get_sim_config
+
+
+def test_config_smoke():
+    get_sim_config()
+
+
+def test_config_input():
+    cin = {'psf_type': 'moffat'}
+    config = get_sim_config(config=cin)
+    assert config['psf_type'] == cin['psf_type']
+
+
+def test_config_pure():
+    cin = {'bands': ['r', 'i']}
+    config = get_sim_config(config=cin)
+
+    assert config['bands'] == cin['bands']
+
+    config['bands'].append('z')
+
+    assert config['bands'] != cin['bands']
+
+
+def test_config_badkey():
+    cin = {'badkey': 5}
+    with pytest.raises(ValueError):
+        get_sim_config(config=cin)


### PR DESCRIPTION
This ensures the input config is not modified.