### PR TITLE
Ring test, correct image center, enable write PSF object to pickle, record flux zero point in output exposure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ wheels/
 .installed.cfg
 *.egg
 MANIFEST
+data
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ venv.bak/
 # mypy
 .mypy_cache/
 pytest_session.txt
+outputs

--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ the DM STack:
 
 [Full Installation with Dependencies](https://github.com/beckermr/mdet-lsst-sim-runs)
 
+
+## Getting the Simulation Input Data
+
+To use galaxy models from WeakLensingDeblending, and to use realistic star masks, get this
+tar ball, untar it and set the $CATSIM_DIR environment variable to that location
+```shell
+wget https://www.cosmo.bnl.gov/www/esheldon/data/catsim.tar.gz
+tar xvfz catsim.tar.gz
+export CATSIM_DIR=/path/to/catsim
+```
+
 ## Example Usage
 
 ### A simple sim
@@ -131,13 +142,3 @@ for trial in range(ntrial):
 ## Documentation
 
 The doc strings for the main public APIs are complete. See them for more details.
-
-## Getting the Simulation Input Data
-
-To use galaxy models from WeakLensingDeblending, and to use realistic star masks, get this
-tar ball, untar it and set the $CATSIM_DIR environment variable to that location
-```shell
-wget https://www.cosmo.bnl.gov/www/esheldon/data/catsim.tar.gz
-tar xvfz catsim.tar.gz
-export CATSIM_DIR=/path/to/catsim
-```

--- a/README.md
+++ b/README.md
@@ -26,12 +26,9 @@ the DM STack:
 ### A simple sim
 ```python
 import numpy as np
-from descwl_shear_sims.sim import (
-    FixedGalaxyCatalog,  # one of the galaxy catalog classes
-    make_sim,  # for making a simulation realization
-    make_psf,  # for making a simple PSF
-)
-
+from descwl_shear_sims.galaxies import FixedGalaxyCatalog
+from descwl_shear_sims.sim import make_sim
+from descwl_shear_sims.psfs import make_fixed_psf
 seed = 8312
 rng = np.random.RandomState(seed)
 
@@ -53,7 +50,7 @@ for trial in range(ntrial):
     )
 
     # make a constant gaussian psf
-    psf = make_psf(psf_type='gauss')
+    psf = make_fixed_psf(psf_type='gauss')
 
     # generate some simulation data, with a particular shear
 
@@ -65,29 +62,17 @@ for trial in range(ntrial):
         g2=0.00,
         psf=psf,
     )
-
-    # the sim_data has keys
-    #    band_data: a dict keyed by band with a list of single-epoch
-    #      observations objects, one for each epoch.  The class is
-    #      SEObs, defined in descwl_shear_sims.se_obs.py and has attributes
-    #      for the image, weight map, wcs, noise image, bmask and a psf
-    #      image generating method get_psf(x, y)
-    #    coadd_wcs:  the wcs for the coadd
-    #    psf_dims:  dimensions of the psf
-    #    coadd_dims: dimensions of the coadd
 ```
 
 ### A sim with lots of features turned on
 
 ```python
 import numpy as np
-from descwl_shear_sims.sim import (
-    WLDeblendGalaxyCatalog,  # one of the galaxy catalog classes
-    StarCatalog,  # star catalog class
-    make_sim,  # for making a simulation realization
-    make_ps_psf,  # for making a power spectrum PSF
-    get_se_dim,  # convert coadd dims to SE dims
-)
+from descwl_shear_sims.galaxies import WLDeblendGalaxyCatalog  # one of the galaxy catalog classes
+from descwl_shear_sims.stars import StarCatalog  # star catalog class
+from descwl_shear_sims.sim import make_sim
+from descwl_shear_sims.psfs import make_ps_psf  # for making a power spectrum PSF
+from descwl_shear_sims.sim import get_se_dim  # convert coadd dims to SE dims
 
 seed = 8312
 rng = np.random.RandomState(seed)

--- a/descwl_shear_sims/constants.py
+++ b/descwl_shear_sims/constants.py
@@ -32,6 +32,3 @@ WORLD_ORIGIN = galsim.CelestialCoord(
     ra=200 * galsim.degrees,
     dec=0 * galsim.degrees,
 )
-
-# minimal radius for random shift
-MIN_R_SHIFT = 0.

--- a/descwl_shear_sims/constants.py
+++ b/descwl_shear_sims/constants.py
@@ -32,3 +32,6 @@ WORLD_ORIGIN = galsim.CelestialCoord(
     ra=200 * galsim.degrees,
     dec=0 * galsim.degrees,
 )
+
+# minimal radius for random shift
+MIN_R_SHIFT = 0.

--- a/descwl_shear_sims/galaxies.py
+++ b/descwl_shear_sims/galaxies.py
@@ -602,7 +602,7 @@ class WLDeblendGalaxyCatalog(object):
             else:
                 area = ((coadd_dim - 2*buff)*SCALE/60)**2
 
-        elif layout == 'random_circle':
+        elif layout == 'random_disk':
             # this layout is random in a circle
             if (coadd_dim - 2*buff) < 2:
                 warnings.warn("dim - 2*buff <= 2, force it to 2.")
@@ -613,7 +613,7 @@ class WLDeblendGalaxyCatalog(object):
                 area = np.pi*radius**2
             del radius
         else:
-            raise ValueError("layout can only be 'random' or 'random_circle' \
+            raise ValueError("layout can only be 'random' or 'random_disk' \
                     for wldeblend")
 
         # a least 1 expected galaxy (used for simple tests)

--- a/descwl_shear_sims/galaxies.py
+++ b/descwl_shear_sims/galaxies.py
@@ -75,10 +75,15 @@ def make_galaxy_catalog(
             )
 
         if gal_type == 'wldeblend':
+            assert layout is not None, \
+                    "Cannot make wldebend catalog with layout=None, please use \
+                    layout='random' or 'random_disk'."
+
             galaxy_catalog = WLDeblendGalaxyCatalog(
                 rng=rng,
                 coadd_dim=coadd_dim,
                 buff=buff,
+                layout=layout,
             )
         elif gal_type in ['fixed', 'varying', 'exp']:  # TODO remove exp
             if layout is None:

--- a/descwl_shear_sims/galaxies.py
+++ b/descwl_shear_sims/galaxies.py
@@ -76,8 +76,8 @@ def make_galaxy_catalog(
 
         if gal_type == 'wldeblend':
             assert layout is not None, \
-                    "Cannot make wldebend catalog with layout=None, please use \
-                    layout='random' or 'random_disk'."
+                "Cannot make wldebend catalog with layout=None, please use \
+                layout='random' or 'random_disk'."
 
             galaxy_catalog = WLDeblendGalaxyCatalog(
                 rng=rng,

--- a/descwl_shear_sims/galaxies.py
+++ b/descwl_shear_sims/galaxies.py
@@ -76,10 +76,6 @@ def make_galaxy_catalog(
 
         if gal_type == 'wldeblend':
             if layout is None:
-                warnings.warn(
-                    "The input layout is None! Force layout to 'random' for \
-                    galaxy_type=wldeblend"
-                )
                 layout = "random"
 
             galaxy_catalog = WLDeblendGalaxyCatalog(

--- a/descwl_shear_sims/galaxies.py
+++ b/descwl_shear_sims/galaxies.py
@@ -48,45 +48,43 @@ def make_galaxy_catalog(
     sep: float, optional
         Separation of pair in arcsec for layout='pair'
     """
-    if layout == 'pair':
+    if layout == "pair":
         if sep is None:
-            raise ValueError(
-                f'send sep= for gal_type {gal_type} and layout {layout}'
-            )
+            raise ValueError(f"send sep= for gal_type {gal_type} and layout {layout}")
         gal_config = get_fixed_gal_config(config=gal_config)
 
-        if gal_type in ['fixed', 'exp']:  # TODO remove exp
+        if gal_type in ["fixed", "exp"]:  # TODO remove exp
             cls = FixedPairGalaxyCatalog
         else:
             cls = PairGalaxyCatalog
 
         galaxy_catalog = cls(
             rng=rng,
-            mag=gal_config['mag'],
-            hlr=gal_config['hlr'],
-            morph=gal_config['morph'],
+            mag=gal_config["mag"],
+            hlr=gal_config["hlr"],
+            morph=gal_config["morph"],
             sep=sep,
         )
 
     else:
         if coadd_dim is None:
             raise ValueError(
-                f'send coadd_dim= for gal_type {gal_type} and layout {layout}'
+                f"send coadd_dim= for gal_type {gal_type} and layout {layout}"
             )
 
-        if gal_type == 'wldeblend':
+        if gal_type == "wldeblend":
             galaxy_catalog = WLDeblendGalaxyCatalog(
                 rng=rng,
                 coadd_dim=coadd_dim,
                 buff=buff,
             )
-        elif gal_type in ['fixed', 'varying', 'exp']:  # TODO remove exp
+        elif gal_type in ["fixed", "varying", "exp"]:  # TODO remove exp
             if layout is None:
                 raise ValueError("send layout= for gal_type '%s'" % gal_type)
 
             gal_config = get_fixed_gal_config(config=gal_config)
 
-            if gal_type == 'fixed':
+            if gal_type == "fixed":
                 cls = FixedGalaxyCatalog
             else:
                 cls = GalaxyCatalog
@@ -96,9 +94,9 @@ def make_galaxy_catalog(
                 coadd_dim=coadd_dim,
                 buff=buff,
                 layout=layout,
-                mag=gal_config['mag'],
-                hlr=gal_config['hlr'],
-                morph=gal_config['morph'],
+                mag=gal_config["mag"],
+                hlr=gal_config["hlr"],
+                morph=gal_config["morph"],
             )
 
         else:
@@ -159,8 +157,9 @@ class FixedGalaxyCatalog(object):
     morph: str
         Galaxy morphology, 'exp', 'dev' or 'bd', 'bdk'.  Default 'exp'
     """
-    def __init__(self, *, rng, coadd_dim, layout, mag, hlr, buff=0, morph='exp'):
-        self.gal_type = 'fixed'
+
+    def __init__(self, *, rng, coadd_dim, layout, mag, hlr, buff=0, morph="exp"):
+        self.gal_type = "fixed"
         self.morph = morph
         self.mag = mag
         self.hlr = hlr
@@ -197,7 +196,7 @@ class FixedGalaxyCatalog(object):
         shifts = []
         for i in range(len(self)):
             objlist.append(self._get_galaxy(flux))
-            shifts.append(galsim.PositionD(sarray['dx'][i], sarray['dy'][i]))
+            shifts.append(galsim.PositionD(sarray["dx"][i], sarray["dy"][i]))
 
         return objlist, shifts
 
@@ -215,13 +214,13 @@ class FixedGalaxyCatalog(object):
         galsim.GSObject
         """
 
-        if self.morph == 'exp':
+        if self.morph == "exp":
             gal = _generate_exp(hlr=self.hlr, flux=flux)
-        elif self.morph == 'dev':
+        elif self.morph == "dev":
             gal = _generate_dev(hlr=self.hlr, flux=flux)
-        elif self.morph == 'bd':
+        elif self.morph == "bd":
             gal = _generate_bd(hlr=self.hlr, flux=flux)
-        elif self.morph == 'bdk':
+        elif self.morph == "bdk":
             gal = _generate_bdk(hlr=self.hlr, flux=flux)
         else:
             raise ValueError(f"bad gal type '{self.morph}'")
@@ -258,12 +257,18 @@ class GalaxyCatalog(FixedGalaxyCatalog):
     morph: str
         Galaxy morphology, 'exp', 'dev' or 'bd', 'bdk'.  Default 'exp'
     """
-    def __init__(self, *, rng, coadd_dim, layout, mag, hlr, buff=0, morph='exp'):
+
+    def __init__(self, *, rng, coadd_dim, layout, mag, hlr, buff=0, morph="exp"):
         super().__init__(
-            rng=rng, coadd_dim=coadd_dim, buff=buff, layout=layout,
-            mag=mag, hlr=hlr, morph=morph,
+            rng=rng,
+            coadd_dim=coadd_dim,
+            buff=buff,
+            layout=layout,
+            mag=mag,
+            hlr=hlr,
+            morph=morph,
         )
-        self.gal_type = 'varying'
+        self.gal_type = "varying"
 
         # we use this to ensure the same galaxies are generated in different
         # bands
@@ -303,24 +308,34 @@ class GalaxyCatalog(FixedGalaxyCatalog):
         galsim.GSObject
         """
 
-        if self.morph == 'exp':
+        if self.morph == "exp":
             gal = _generate_exp(
-                hlr=self.hlr, flux=flux, vary=True, rng=self._morph_rng,
-            )
-        elif self.morph == 'dev':
-            gal = _generate_dev(
-                hlr=self.hlr, flux=flux, vary=True, rng=self._morph_rng,
-            )
-        elif self.morph == 'bd':
-            gal = _generate_bd(
-                hlr=self.hlr, flux=flux,
-                vary=True, rng=self._morph_rng,
-            )
-        elif self.morph == 'bdk':
-            gal = _generate_bdk(
-                hlr=self.hlr, flux=flux,
+                hlr=self.hlr,
+                flux=flux,
                 vary=True,
-                rng=self._morph_rng, gsrng=self._gs_morph_rng,
+                rng=self._morph_rng,
+            )
+        elif self.morph == "dev":
+            gal = _generate_dev(
+                hlr=self.hlr,
+                flux=flux,
+                vary=True,
+                rng=self._morph_rng,
+            )
+        elif self.morph == "bd":
+            gal = _generate_bd(
+                hlr=self.hlr,
+                flux=flux,
+                vary=True,
+                rng=self._morph_rng,
+            )
+        elif self.morph == "bdk":
+            gal = _generate_bdk(
+                hlr=self.hlr,
+                flux=flux,
+                vary=True,
+                rng=self._morph_rng,
+                gsrng=self._gs_morph_rng,
             )
         else:
             raise ValueError(f"bad morph '{self.morph}'")
@@ -348,11 +363,12 @@ def _generate_dev(hlr, flux, vary=False, rng=None):
 
 
 def _generate_bd(
-    hlr, flux,
+    hlr,
+    flux,
     vary=False,
     rng=None,
     max_bulge_shift_frac=0.1,  # fraction of hlr
-    max_bulge_rot=np.pi/4,
+    max_bulge_rot=np.pi / 4,
 ):
 
     if vary:
@@ -360,7 +376,7 @@ def _generate_bd(
     else:
         bulge_frac = 0.5
 
-    disk_frac = (1.0 - bulge_frac)
+    disk_frac = 1.0 - bulge_frac
 
     bulge = DeVaucouleurs(half_light_radius=hlr, flux=flux * bulge_frac)
     disk = Exponential(half_light_radius=hlr, flux=flux * disk_frac)
@@ -382,14 +398,15 @@ def _generate_bd(
 
 
 def _generate_bdk(
-    hlr, flux,
+    hlr,
+    flux,
     vary=False,
     rng=None,
     gsrng=None,
     knots_hlr_frac=0.25,
     max_knots_disk_frac=0.1,  # fraction of disk light
     max_bulge_shift_frac=0.1,  # fraction of hlr
-    max_bulge_rot=np.pi/4,
+    max_bulge_rot=np.pi / 4,
 ):
 
     if vary:
@@ -397,7 +414,7 @@ def _generate_bdk(
     else:
         bulge_frac = 0.5
 
-    all_disk_frac = (1.0 - bulge_frac)
+    all_disk_frac = 1.0 - bulge_frac
 
     knots_hlr = knots_hlr_frac * hlr
     if vary:
@@ -440,12 +457,12 @@ def _generate_bdk(
 
 
 def _generate_bulge_frac(rng):
-    assert rng is not None, 'send rng to generate bulge fraction'
+    assert rng is not None, "send rng to generate bulge fraction"
     return rng.uniform(low=0.0, high=1.0)
 
 
 def _generate_g1g2(rng, std=0.2):
-    assert rng is not None, 'send rng to vary shape'
+    assert rng is not None, "send rng to vary shape"
     while True:
         g1, g2 = rng.normal(scale=std, size=2)
         g = np.sqrt(g1**2 + g2**2)
@@ -456,8 +473,8 @@ def _generate_g1g2(rng, std=0.2):
 
 
 def _generate_bulge_shift(rng, hlr, max_bulge_shift_frac):
-    bulge_shift = rng.uniform(low=0.0, high=max_bulge_shift_frac*hlr)
-    bulge_shift_angle = rng.uniform(low=0, high=2*np.pi)
+    bulge_shift = rng.uniform(low=0.0, high=max_bulge_shift_frac * hlr)
+    bulge_shift_angle = rng.uniform(low=0, high=2 * np.pi)
     bulge_shiftx = bulge_shift * np.cos(bulge_shift_angle)
     bulge_shifty = bulge_shift * np.sin(bulge_shift_angle)
 
@@ -466,14 +483,16 @@ def _generate_bulge_shift(rng, hlr, max_bulge_shift_frac):
 
 def _shift_bulge(rng, bulge, hlr, max_bulge_shift_frac):
     bulge_shiftx, bulge_shifty = _generate_bulge_shift(
-        rng, hlr, max_bulge_shift_frac,
+        rng,
+        hlr,
+        max_bulge_shift_frac,
     )
     return bulge.shift(bulge_shiftx, bulge_shifty)
 
 
 def _rotate_bulge(rng, max_bulge_rot, g1, g2):
-    assert rng is not None, 'send rng to rotate bulge'
-    bulge_rot = rng.uniform(low=-max_bulge_rot, high=max_bulge_rot/4)
+    assert rng is not None, "send rng to rotate bulge"
+    bulge_rot = rng.uniform(low=-max_bulge_rot, high=max_bulge_rot / 4)
     return _rotate_shape(g1, g2, bulge_rot)
 
 
@@ -489,7 +508,7 @@ def _rotate_shape(g1, g2, theta_radians):
 
 
 def _generate_knots_sub_frac(rng, max_knots_disk_frac):
-    assert rng is not None, 'send rng to generate knots sub frac'
+    assert rng is not None, "send rng to generate knots sub frac"
     return rng.uniform(low=0.0, high=max_knots_disk_frac)
 
 
@@ -517,8 +536,9 @@ class FixedPairGalaxyCatalog(FixedGalaxyCatalog):
     morph: str
         Galaxy morphology, 'exp', 'dev' or 'bd', 'bdk'.  Default 'exp'
     """
-    def __init__(self, *, rng, mag, hlr, sep, morph='exp'):
-        self.gal_type = 'fixed'
+
+    def __init__(self, *, rng, mag, hlr, sep, morph="exp"):
+        self.gal_type = "fixed"
         self.morph = morph
         self.mag = mag
         self.hlr = hlr
@@ -554,8 +574,9 @@ class PairGalaxyCatalog(GalaxyCatalog):
     morph: str
         Galaxy morphology, 'exp', 'dev' or 'bd', 'bdk'.  Default 'exp'
     """
-    def __init__(self, *, rng, mag, hlr, sep, morph='exp'):
-        self.gal_type = 'varying'
+
+    def __init__(self, *, rng, mag, hlr, sep, morph="exp"):
+        self.gal_type = "varying"
         self.morph = morph
         self.mag = mag
         self.hlr = hlr
@@ -586,38 +607,41 @@ class WLDeblendGalaxyCatalog(object):
     layout: str, optional
 
     """
-    def __init__(self, *, rng, coadd_dim, buff=0, layout='random'):
-        self.gal_type = 'wldeblend'
+
+    def __init__(self, *, rng, coadd_dim, buff=0, layout="random"):
+        self.gal_type = "wldeblend"
         self.rng = rng
 
         self._wldeblend_cat = read_wldeblend_cat(rng)
 
         # one square degree catalog, convert to arcmin
         gal_dens = self._wldeblend_cat.size / (60 * 60)
-        if layout == 'random':
+        if layout == "random":
             # this layout is random in a square
-            if (coadd_dim - 2*buff) < 2:
+            if (coadd_dim - 2 * buff) < 2:
                 warnings.warn("dim - 2*buff <= 2, force it to 2.")
-                area = (2**SCALE/60)**2.
+                area = (2**SCALE / 60) ** 2.0
             else:
-                area = ((coadd_dim - 2*buff)*SCALE/60)**2
+                area = ((coadd_dim - 2 * buff) * SCALE / 60) ** 2
 
-        elif layout == 'random_circle':
+        elif layout == "random_circle":
             # this layout is random in a circle
-            if (coadd_dim - 2*buff) < 2:
+            if (coadd_dim - 2 * buff) < 2:
                 warnings.warn("dim - 2*buff <= 2, force it to 2.")
-                radius = 2.*SCALE/60
-                area = np.pi*radius**2
+                radius = 2.0 * SCALE / 60
+                area = np.pi * radius**2
             else:
-                radius = (coadd_dim/2. - buff)*SCALE/60
-                area = np.pi*radius**2
+                radius = (coadd_dim / 2.0 - buff) * SCALE / 60
+                area = np.pi * radius**2
             del radius
         else:
-            raise ValueError("layout can only be 'random' or 'random_circle' \
-                    for wldeblend")
+            raise ValueError(
+                "layout can only be 'random' or 'random_circle' \
+                    for wldeblend"
+            )
 
         # a least 1 expected galaxy (used for simple tests)
-        nobj_mean = max(area * gal_dens,1)
+        nobj_mean = max(area * gal_dens, 1)
 
         nobj = rng.poisson(nobj_mean)
 
@@ -670,7 +694,7 @@ class WLDeblendGalaxyCatalog(object):
         shifts = []
         for i in range(len(self)):
             objlist.append(self._get_galaxy(builder, band, i))
-            shifts.append(galsim.PositionD(sarray['dx'][i], sarray['dy'][i]))
+            shifts.append(galsim.PositionD(sarray["dx"][i], sarray["dy"][i]))
 
         return objlist, shifts
 
@@ -721,8 +745,8 @@ def read_wldeblend_cat(rng):
     array with fields
     """
     fname = os.path.join(
-        os.environ.get('CATSIM_DIR', '.'),
-        'OneDegSq.fits',
+        os.environ.get("CATSIM_DIR", "."),
+        "OneDegSq.fits",
     )
 
     # not thread safe

--- a/descwl_shear_sims/galaxies.py
+++ b/descwl_shear_sims/galaxies.py
@@ -602,7 +602,7 @@ class WLDeblendGalaxyCatalog(object):
             else:
                 area = ((coadd_dim - 2*buff)*SCALE/60)**2
 
-        elif layout=='random_circle':
+        elif layout == 'random_circle':
             # this layout is random in a circle
             if (coadd_dim - 2*buff) < 2:
                 warnings.warn("dim - 2*buff <= 2, force it to 2.")

--- a/descwl_shear_sims/galaxies.py
+++ b/descwl_shear_sims/galaxies.py
@@ -603,7 +603,7 @@ class WLDeblendGalaxyCatalog(object):
             del radius
         else:
             raise ValueError("layout can only be 'random' or 'random_circle' for wldeblend")
-        print(area)
+        # print(area)
 
         nobj_mean = area * gal_dens
         nobj = rng.poisson(nobj_mean)
@@ -615,8 +615,8 @@ class WLDeblendGalaxyCatalog(object):
             layout=layout,
             nobj=nobj,
         )
-        print(np.min(self.shifts_array['dx'])/SCALE,np.max(self.shifts_array['dx'])/SCALE)
-        print(np.min(self.shifts_array['dy'])/SCALE,np.max(self.shifts_array['dy'])/SCALE)
+        # print(np.min(self.shifts_array['dx'])/SCALE,np.max(self.shifts_array['dx'])/SCALE)
+        # print(np.min(self.shifts_array['dy'])/SCALE,np.max(self.shifts_array['dy'])/SCALE)
 
         num = len(self)
         self.indices = self.rng.randint(

--- a/descwl_shear_sims/galaxies.py
+++ b/descwl_shear_sims/galaxies.py
@@ -75,9 +75,8 @@ def make_galaxy_catalog(
             )
 
         if gal_type == 'wldeblend':
-            assert layout is not None, \
-                "Cannot make wldebend catalog with layout=None, please use \
-                layout='random' or 'random_disk'."
+            if layout is None:
+                raise ValueError("send layout= for gal_type '%s'" % gal_type)
 
             galaxy_catalog = WLDeblendGalaxyCatalog(
                 rng=rng,

--- a/descwl_shear_sims/galaxies.py
+++ b/descwl_shear_sims/galaxies.py
@@ -617,7 +617,7 @@ class WLDeblendGalaxyCatalog(object):
                     for wldeblend")
 
         # a least 1 expected galaxy (used for simple tests)
-        nobj_mean = max(area * gal_dens,1)
+        nobj_mean = max(area * gal_dens, 1)
 
         nobj = rng.poisson(nobj_mean)
 

--- a/descwl_shear_sims/galaxies.py
+++ b/descwl_shear_sims/galaxies.py
@@ -617,7 +617,7 @@ class WLDeblendGalaxyCatalog(object):
                     for wldeblend")
 
         # a least 1 expected galaxy (used for simple tests)
-        nobj_mean = area * gal_dens
+        nobj_mean = max(area * gal_dens,1)
 
         nobj = rng.poisson(nobj_mean)
 

--- a/descwl_shear_sims/galaxies.py
+++ b/descwl_shear_sims/galaxies.py
@@ -76,7 +76,11 @@ def make_galaxy_catalog(
 
         if gal_type == 'wldeblend':
             if layout is None:
-                raise ValueError("send layout= for gal_type '%s'" % gal_type)
+                warnings.warn(
+                    "The input layout is None! Force layout to 'random' for \
+                    galaxy_type=wldeblend"
+                )
+                layout = "random"
 
             galaxy_catalog = WLDeblendGalaxyCatalog(
                 rng=rng,

--- a/descwl_shear_sims/galaxies.py
+++ b/descwl_shear_sims/galaxies.py
@@ -586,7 +586,7 @@ class WLDeblendGalaxyCatalog(object):
     layout: str, optional
 
     """
-    def __init__(self, *, rng, coadd_dim, buff=0,layout='random'):
+    def __init__(self, *, rng, coadd_dim, buff=0, layout='random'):
         self.gal_type = 'wldeblend'
         self.rng = rng
 
@@ -594,28 +594,30 @@ class WLDeblendGalaxyCatalog(object):
 
         # one square degree catalog, convert to arcmin
         gal_dens = self._wldeblend_cat.size / (60 * 60)
-        if layout=='random':
+        if layout == 'random':
             # this layout is random in a square
-            if (coadd_dim - 2*buff)<2:
+            if (coadd_dim - 2*buff) < 2:
                 warnings.warn("dim - 2*buff <= 2, force it to 2.")
-                area    =   (2**SCALE/60)**2.
+                area = (2**SCALE/60)**2.
             else:
-                area    =   ((coadd_dim - 2*buff)*SCALE/60)**2
+                area = ((coadd_dim - 2*buff)*SCALE/60)**2
 
         elif layout=='random_circle':
             # this layout is random in a circle
-            if (coadd_dim - 2*buff)<2:
+            if (coadd_dim - 2*buff) < 2:
                 warnings.warn("dim - 2*buff <= 2, force it to 2.")
-                radius  =   2.*SCALE/60
-                area    =   np.pi*radius**2
+                radius = 2.*SCALE/60
+                area = np.pi*radius**2
             else:
-                radius=(coadd_dim/2. - buff)*SCALE/60
+                radius = (coadd_dim/2. - buff)*SCALE/60
                 area = np.pi*radius**2
             del radius
         else:
-            raise ValueError("layout can only be 'random' or 'random_circle' for wldeblend")
+            raise ValueError("layout can only be 'random' or 'random_circle' \
+                    for wldeblend")
 
-        nobj_mean = max(area * gal_dens,1) # a least 1 expected galaxy (used for simple tests)
+        # a least 1 expected galaxy (used for simple tests)
+        nobj_mean = area * gal_dens
 
         nobj = rng.poisson(nobj_mean)
 

--- a/descwl_shear_sims/galaxies.py
+++ b/descwl_shear_sims/galaxies.py
@@ -48,43 +48,45 @@ def make_galaxy_catalog(
     sep: float, optional
         Separation of pair in arcsec for layout='pair'
     """
-    if layout == "pair":
+    if layout == 'pair':
         if sep is None:
-            raise ValueError(f"send sep= for gal_type {gal_type} and layout {layout}")
+            raise ValueError(
+                f'send sep= for gal_type {gal_type} and layout {layout}'
+            )
         gal_config = get_fixed_gal_config(config=gal_config)
 
-        if gal_type in ["fixed", "exp"]:  # TODO remove exp
+        if gal_type in ['fixed', 'exp']:  # TODO remove exp
             cls = FixedPairGalaxyCatalog
         else:
             cls = PairGalaxyCatalog
 
         galaxy_catalog = cls(
             rng=rng,
-            mag=gal_config["mag"],
-            hlr=gal_config["hlr"],
-            morph=gal_config["morph"],
+            mag=gal_config['mag'],
+            hlr=gal_config['hlr'],
+            morph=gal_config['morph'],
             sep=sep,
         )
 
     else:
         if coadd_dim is None:
             raise ValueError(
-                f"send coadd_dim= for gal_type {gal_type} and layout {layout}"
+                f'send coadd_dim= for gal_type {gal_type} and layout {layout}'
             )
 
-        if gal_type == "wldeblend":
+        if gal_type == 'wldeblend':
             galaxy_catalog = WLDeblendGalaxyCatalog(
                 rng=rng,
                 coadd_dim=coadd_dim,
                 buff=buff,
             )
-        elif gal_type in ["fixed", "varying", "exp"]:  # TODO remove exp
+        elif gal_type in ['fixed', 'varying', 'exp']:  # TODO remove exp
             if layout is None:
                 raise ValueError("send layout= for gal_type '%s'" % gal_type)
 
             gal_config = get_fixed_gal_config(config=gal_config)
 
-            if gal_type == "fixed":
+            if gal_type == 'fixed':
                 cls = FixedGalaxyCatalog
             else:
                 cls = GalaxyCatalog
@@ -94,9 +96,9 @@ def make_galaxy_catalog(
                 coadd_dim=coadd_dim,
                 buff=buff,
                 layout=layout,
-                mag=gal_config["mag"],
-                hlr=gal_config["hlr"],
-                morph=gal_config["morph"],
+                mag=gal_config['mag'],
+                hlr=gal_config['hlr'],
+                morph=gal_config['morph'],
             )
 
         else:
@@ -157,9 +159,8 @@ class FixedGalaxyCatalog(object):
     morph: str
         Galaxy morphology, 'exp', 'dev' or 'bd', 'bdk'.  Default 'exp'
     """
-
-    def __init__(self, *, rng, coadd_dim, layout, mag, hlr, buff=0, morph="exp"):
-        self.gal_type = "fixed"
+    def __init__(self, *, rng, coadd_dim, layout, mag, hlr, buff=0, morph='exp'):
+        self.gal_type = 'fixed'
         self.morph = morph
         self.mag = mag
         self.hlr = hlr
@@ -196,7 +197,7 @@ class FixedGalaxyCatalog(object):
         shifts = []
         for i in range(len(self)):
             objlist.append(self._get_galaxy(flux))
-            shifts.append(galsim.PositionD(sarray["dx"][i], sarray["dy"][i]))
+            shifts.append(galsim.PositionD(sarray['dx'][i], sarray['dy'][i]))
 
         return objlist, shifts
 
@@ -214,13 +215,13 @@ class FixedGalaxyCatalog(object):
         galsim.GSObject
         """
 
-        if self.morph == "exp":
+        if self.morph == 'exp':
             gal = _generate_exp(hlr=self.hlr, flux=flux)
-        elif self.morph == "dev":
+        elif self.morph == 'dev':
             gal = _generate_dev(hlr=self.hlr, flux=flux)
-        elif self.morph == "bd":
+        elif self.morph == 'bd':
             gal = _generate_bd(hlr=self.hlr, flux=flux)
-        elif self.morph == "bdk":
+        elif self.morph == 'bdk':
             gal = _generate_bdk(hlr=self.hlr, flux=flux)
         else:
             raise ValueError(f"bad gal type '{self.morph}'")
@@ -257,18 +258,12 @@ class GalaxyCatalog(FixedGalaxyCatalog):
     morph: str
         Galaxy morphology, 'exp', 'dev' or 'bd', 'bdk'.  Default 'exp'
     """
-
-    def __init__(self, *, rng, coadd_dim, layout, mag, hlr, buff=0, morph="exp"):
+    def __init__(self, *, rng, coadd_dim, layout, mag, hlr, buff=0, morph='exp'):
         super().__init__(
-            rng=rng,
-            coadd_dim=coadd_dim,
-            buff=buff,
-            layout=layout,
-            mag=mag,
-            hlr=hlr,
-            morph=morph,
+            rng=rng, coadd_dim=coadd_dim, buff=buff, layout=layout,
+            mag=mag, hlr=hlr, morph=morph,
         )
-        self.gal_type = "varying"
+        self.gal_type = 'varying'
 
         # we use this to ensure the same galaxies are generated in different
         # bands
@@ -308,34 +303,24 @@ class GalaxyCatalog(FixedGalaxyCatalog):
         galsim.GSObject
         """
 
-        if self.morph == "exp":
+        if self.morph == 'exp':
             gal = _generate_exp(
-                hlr=self.hlr,
-                flux=flux,
-                vary=True,
-                rng=self._morph_rng,
+                hlr=self.hlr, flux=flux, vary=True, rng=self._morph_rng,
             )
-        elif self.morph == "dev":
+        elif self.morph == 'dev':
             gal = _generate_dev(
-                hlr=self.hlr,
-                flux=flux,
-                vary=True,
-                rng=self._morph_rng,
+                hlr=self.hlr, flux=flux, vary=True, rng=self._morph_rng,
             )
-        elif self.morph == "bd":
+        elif self.morph == 'bd':
             gal = _generate_bd(
-                hlr=self.hlr,
-                flux=flux,
-                vary=True,
-                rng=self._morph_rng,
+                hlr=self.hlr, flux=flux,
+                vary=True, rng=self._morph_rng,
             )
-        elif self.morph == "bdk":
+        elif self.morph == 'bdk':
             gal = _generate_bdk(
-                hlr=self.hlr,
-                flux=flux,
+                hlr=self.hlr, flux=flux,
                 vary=True,
-                rng=self._morph_rng,
-                gsrng=self._gs_morph_rng,
+                rng=self._morph_rng, gsrng=self._gs_morph_rng,
             )
         else:
             raise ValueError(f"bad morph '{self.morph}'")
@@ -363,12 +348,11 @@ def _generate_dev(hlr, flux, vary=False, rng=None):
 
 
 def _generate_bd(
-    hlr,
-    flux,
+    hlr, flux,
     vary=False,
     rng=None,
     max_bulge_shift_frac=0.1,  # fraction of hlr
-    max_bulge_rot=np.pi / 4,
+    max_bulge_rot=np.pi/4,
 ):
 
     if vary:
@@ -376,7 +360,7 @@ def _generate_bd(
     else:
         bulge_frac = 0.5
 
-    disk_frac = 1.0 - bulge_frac
+    disk_frac = (1.0 - bulge_frac)
 
     bulge = DeVaucouleurs(half_light_radius=hlr, flux=flux * bulge_frac)
     disk = Exponential(half_light_radius=hlr, flux=flux * disk_frac)
@@ -398,15 +382,14 @@ def _generate_bd(
 
 
 def _generate_bdk(
-    hlr,
-    flux,
+    hlr, flux,
     vary=False,
     rng=None,
     gsrng=None,
     knots_hlr_frac=0.25,
     max_knots_disk_frac=0.1,  # fraction of disk light
     max_bulge_shift_frac=0.1,  # fraction of hlr
-    max_bulge_rot=np.pi / 4,
+    max_bulge_rot=np.pi/4,
 ):
 
     if vary:
@@ -414,7 +397,7 @@ def _generate_bdk(
     else:
         bulge_frac = 0.5
 
-    all_disk_frac = 1.0 - bulge_frac
+    all_disk_frac = (1.0 - bulge_frac)
 
     knots_hlr = knots_hlr_frac * hlr
     if vary:
@@ -457,12 +440,12 @@ def _generate_bdk(
 
 
 def _generate_bulge_frac(rng):
-    assert rng is not None, "send rng to generate bulge fraction"
+    assert rng is not None, 'send rng to generate bulge fraction'
     return rng.uniform(low=0.0, high=1.0)
 
 
 def _generate_g1g2(rng, std=0.2):
-    assert rng is not None, "send rng to vary shape"
+    assert rng is not None, 'send rng to vary shape'
     while True:
         g1, g2 = rng.normal(scale=std, size=2)
         g = np.sqrt(g1**2 + g2**2)
@@ -473,8 +456,8 @@ def _generate_g1g2(rng, std=0.2):
 
 
 def _generate_bulge_shift(rng, hlr, max_bulge_shift_frac):
-    bulge_shift = rng.uniform(low=0.0, high=max_bulge_shift_frac * hlr)
-    bulge_shift_angle = rng.uniform(low=0, high=2 * np.pi)
+    bulge_shift = rng.uniform(low=0.0, high=max_bulge_shift_frac*hlr)
+    bulge_shift_angle = rng.uniform(low=0, high=2*np.pi)
     bulge_shiftx = bulge_shift * np.cos(bulge_shift_angle)
     bulge_shifty = bulge_shift * np.sin(bulge_shift_angle)
 
@@ -483,16 +466,14 @@ def _generate_bulge_shift(rng, hlr, max_bulge_shift_frac):
 
 def _shift_bulge(rng, bulge, hlr, max_bulge_shift_frac):
     bulge_shiftx, bulge_shifty = _generate_bulge_shift(
-        rng,
-        hlr,
-        max_bulge_shift_frac,
+        rng, hlr, max_bulge_shift_frac,
     )
     return bulge.shift(bulge_shiftx, bulge_shifty)
 
 
 def _rotate_bulge(rng, max_bulge_rot, g1, g2):
-    assert rng is not None, "send rng to rotate bulge"
-    bulge_rot = rng.uniform(low=-max_bulge_rot, high=max_bulge_rot / 4)
+    assert rng is not None, 'send rng to rotate bulge'
+    bulge_rot = rng.uniform(low=-max_bulge_rot, high=max_bulge_rot/4)
     return _rotate_shape(g1, g2, bulge_rot)
 
 
@@ -508,7 +489,7 @@ def _rotate_shape(g1, g2, theta_radians):
 
 
 def _generate_knots_sub_frac(rng, max_knots_disk_frac):
-    assert rng is not None, "send rng to generate knots sub frac"
+    assert rng is not None, 'send rng to generate knots sub frac'
     return rng.uniform(low=0.0, high=max_knots_disk_frac)
 
 
@@ -536,9 +517,8 @@ class FixedPairGalaxyCatalog(FixedGalaxyCatalog):
     morph: str
         Galaxy morphology, 'exp', 'dev' or 'bd', 'bdk'.  Default 'exp'
     """
-
-    def __init__(self, *, rng, mag, hlr, sep, morph="exp"):
-        self.gal_type = "fixed"
+    def __init__(self, *, rng, mag, hlr, sep, morph='exp'):
+        self.gal_type = 'fixed'
         self.morph = morph
         self.mag = mag
         self.hlr = hlr
@@ -574,9 +554,8 @@ class PairGalaxyCatalog(GalaxyCatalog):
     morph: str
         Galaxy morphology, 'exp', 'dev' or 'bd', 'bdk'.  Default 'exp'
     """
-
-    def __init__(self, *, rng, mag, hlr, sep, morph="exp"):
-        self.gal_type = "varying"
+    def __init__(self, *, rng, mag, hlr, sep, morph='exp'):
+        self.gal_type = 'varying'
         self.morph = morph
         self.mag = mag
         self.hlr = hlr
@@ -607,41 +586,38 @@ class WLDeblendGalaxyCatalog(object):
     layout: str, optional
 
     """
-
-    def __init__(self, *, rng, coadd_dim, buff=0, layout="random"):
-        self.gal_type = "wldeblend"
+    def __init__(self, *, rng, coadd_dim, buff=0, layout='random'):
+        self.gal_type = 'wldeblend'
         self.rng = rng
 
         self._wldeblend_cat = read_wldeblend_cat(rng)
 
         # one square degree catalog, convert to arcmin
         gal_dens = self._wldeblend_cat.size / (60 * 60)
-        if layout == "random":
+        if layout == 'random':
             # this layout is random in a square
-            if (coadd_dim - 2 * buff) < 2:
+            if (coadd_dim - 2*buff) < 2:
                 warnings.warn("dim - 2*buff <= 2, force it to 2.")
-                area = (2**SCALE / 60) ** 2.0
+                area = (2**SCALE/60)**2.
             else:
-                area = ((coadd_dim - 2 * buff) * SCALE / 60) ** 2
+                area = ((coadd_dim - 2*buff)*SCALE/60)**2
 
-        elif layout == "random_circle":
+        elif layout == 'random_circle':
             # this layout is random in a circle
-            if (coadd_dim - 2 * buff) < 2:
+            if (coadd_dim - 2*buff) < 2:
                 warnings.warn("dim - 2*buff <= 2, force it to 2.")
-                radius = 2.0 * SCALE / 60
-                area = np.pi * radius**2
+                radius = 2.*SCALE/60
+                area = np.pi*radius**2
             else:
-                radius = (coadd_dim / 2.0 - buff) * SCALE / 60
-                area = np.pi * radius**2
+                radius = (coadd_dim/2. - buff)*SCALE/60
+                area = np.pi*radius**2
             del radius
         else:
-            raise ValueError(
-                "layout can only be 'random' or 'random_circle' \
-                    for wldeblend"
-            )
+            raise ValueError("layout can only be 'random' or 'random_circle' \
+                    for wldeblend")
 
         # a least 1 expected galaxy (used for simple tests)
-        nobj_mean = max(area * gal_dens, 1)
+        nobj_mean = max(area * gal_dens,1)
 
         nobj = rng.poisson(nobj_mean)
 
@@ -694,7 +670,7 @@ class WLDeblendGalaxyCatalog(object):
         shifts = []
         for i in range(len(self)):
             objlist.append(self._get_galaxy(builder, band, i))
-            shifts.append(galsim.PositionD(sarray["dx"][i], sarray["dy"][i]))
+            shifts.append(galsim.PositionD(sarray['dx'][i], sarray['dy'][i]))
 
         return objlist, shifts
 
@@ -745,8 +721,8 @@ def read_wldeblend_cat(rng):
     array with fields
     """
     fname = os.path.join(
-        os.environ.get("CATSIM_DIR", "."),
-        "OneDegSq.fits",
+        os.environ.get('CATSIM_DIR', '.'),
+        'OneDegSq.fits',
     )
 
     # not thread safe

--- a/descwl_shear_sims/shifts.py
+++ b/descwl_shear_sims/shifts.py
@@ -39,29 +39,29 @@ def get_shifts(
         The separation in arcseconds for layout='pair'
     """
 
-    if layout == "pair":
+    if layout == 'pair':
 
         if sep is None:
-            raise ValueError(f"send sep= for layout {layout}")
+            raise ValueError(f'send sep= for layout {layout}')
 
         shifts = get_pair_shifts(rng=rng, sep=sep)
     else:
 
         if coadd_dim is None:
-            raise ValueError(f"send coadd_dim= for layout {layout}")
+            raise ValueError(f'send coadd_dim= for layout {layout}')
 
-        if layout == "grid":
+        if layout == 'grid':
             shifts = get_grid_shifts(
                 rng=rng,
                 dim=coadd_dim,
                 buff=buff,
                 spacing=GRID_SPACING,
             )
-        elif layout == "random":
+        elif layout == 'random':
             # area covered by objects
             if nobj is None:
-                area = ((coadd_dim - 2 * buff) * SCALE / 60) ** 2
-                nobj_mean = max(area * RANDOM_DENSITY, 1)  # at least 1 gal
+                area = ((coadd_dim - 2*buff)*SCALE/60)**2
+                nobj_mean = max(area * RANDOM_DENSITY, 1)
                 nobj = rng.poisson(nobj_mean)
 
             shifts = get_random_shifts(
@@ -70,13 +70,13 @@ def get_shifts(
                 buff=buff,
                 size=nobj,
             )
-        elif layout == "random_circle":
+        elif layout == 'random_circle':
             # randomly distributed in a circle
             # area covered by objects
             if nobj is None:
-                radius = (coadd_dim / 2.0 - buff) * SCALE / 60.0
-                area = np.pi * radius**2
-                nobj_mean = max(area * RANDOM_DENSITY, 1)  # at least 1 gal
+                radius = (coadd_dim/2. - buff)*SCALE/60.
+                area = np.pi*radius**2
+                nobj_mean = max(area * RANDOM_DENSITY, 1)
                 nobj = rng.poisson(nobj_mean)
 
             shifts = get_random_circle_shifts(
@@ -85,7 +85,7 @@ def get_shifts(
                 buff=buff,
                 size=nobj,
             )
-        elif layout == "hex":
+        elif layout == 'hex':
             shifts = get_hex_shifts(
                 rng=rng,
                 dim=coadd_dim,
@@ -121,7 +121,7 @@ def get_hex_shifts(*, rng, dim, buff, spacing):
     """
     from hexalattice.hexalattice import create_hex_grid
 
-    width = (dim - 2 * buff) * SCALE
+    width = (dim - 2*buff) * SCALE
     n_on_side = int(width / spacing) + 1
 
     nx = int(n_on_side * np.sqrt(2))
@@ -141,7 +141,7 @@ def get_hex_shifts(*, rng, dim, buff, spacing):
     upos += SCALE * rng.uniform(low=-0.5, high=0.5, size=upos.shape[0])
     vpos += SCALE * rng.uniform(low=-0.5, high=0.5, size=vpos.shape[0])
 
-    pos_bounds = (-width / 2, width / 2)
+    pos_bounds = (-width/2, width/2)
     msk = (
         (upos >= pos_bounds[0])
         & (upos <= pos_bounds[1])
@@ -152,7 +152,7 @@ def get_hex_shifts(*, rng, dim, buff, spacing):
     vpos = vpos[msk]
 
     ntot = upos.shape[0]
-    shifts = np.zeros(ntot, dtype=[("dx", "f8"), ("dy", "f8")])
+    shifts = np.zeros(ntot, dtype=[('dx', 'f8'), ('dy', 'f8')])
     shifts["dx"] = upos
     shifts["dy"] = vpos
 
@@ -181,32 +181,32 @@ def get_grid_shifts(*, rng, dim, buff, spacing):
         arcsec
     """
 
-    width = (dim - 2 * buff) * SCALE
+    width = (dim - 2*buff) * SCALE
     n_on_side = int(dim / spacing * SCALE)
 
     ntot = n_on_side**2
 
     # ix/iy are really on the sky
-    grid = spacing * (np.arange(n_on_side) - (n_on_side - 1) / 2)
+    grid = spacing*(np.arange(n_on_side) - (n_on_side-1)/2)
 
-    shifts = np.zeros(ntot, dtype=[("dx", "f8"), ("dy", "f8")])
+    shifts = np.zeros(ntot, dtype=[('dx', 'f8'), ('dy', 'f8')])
 
     i = 0
     for ix in range(n_on_side):
         for iy in range(n_on_side):
-            dx = grid[ix] + SCALE * rng.uniform(low=-0.5, high=0.5)
-            dy = grid[iy] + SCALE * rng.uniform(low=-0.5, high=0.5)
+            dx = grid[ix] + SCALE*rng.uniform(low=-0.5, high=0.5)
+            dy = grid[iy] + SCALE*rng.uniform(low=-0.5, high=0.5)
 
-            shifts["dx"][i] = dx
-            shifts["dy"][i] = dy
+            shifts['dx'][i] = dx
+            shifts['dy'][i] = dy
             i += 1
 
-    pos_bounds = (-width / 2, width / 2)
+    pos_bounds = (-width/2, width/2)
     msk = (
-        (shifts["dx"] >= pos_bounds[0])
-        & (shifts["dx"] <= pos_bounds[1])
-        & (shifts["dy"] >= pos_bounds[0])
-        & (shifts["dy"] <= pos_bounds[1])
+        (shifts['dx'] >= pos_bounds[0])
+        & (shifts['dx'] <= pos_bounds[1])
+        & (shifts['dy'] >= pos_bounds[0])
+        & (shifts['dy'] <= pos_bounds[1])
     )
     shifts = shifts[msk]
 
@@ -235,21 +235,20 @@ def get_random_shifts(*, rng, dim, buff, size):
         arcsec
     """
 
-    halfwidth = (dim - 2 * buff) / 2.0
+    halfwidth = (dim - 2*buff)/2.0
     if halfwidth < MIN_R_SHIFT:
         # prevent it from being unrealisticly small
-        warnings.warn(
-            "dim - 2*buff < %s, force halfwidth to %s" % (MIN_R_SHIFT, MIN_R_SHIFT)
-        )
+        warnings.warn("dim - 2*buff < %s, force halfwidth to %s" \
+                %(MIN_R_SHIFT, MIN_R_SHIFT))
         halfwidth = MIN_R_SHIFT
 
-    low = -halfwidth * SCALE
-    high = halfwidth * SCALE
+    low = -halfwidth*SCALE
+    high = halfwidth*SCALE
 
-    shifts = np.zeros(size, dtype=[("dx", "f8"), ("dy", "f8")])
+    shifts = np.zeros(size, dtype=[('dx', 'f8'), ('dy', 'f8')])
 
-    shifts["dx"] = rng.uniform(low=low, high=high, size=size)
-    shifts["dy"] = rng.uniform(low=low, high=high, size=size)
+    shifts['dx'] = rng.uniform(low=low, high=high, size=size)
+    shifts['dy'] = rng.uniform(low=low, high=high, size=size)
 
     return shifts
 
@@ -276,22 +275,21 @@ def get_random_circle_shifts(*, rng, dim, buff, size):
         arcsec
     """
 
-    radius = (dim - 2 * buff) / 2.0 * SCALE
+    radius = (dim - 2*buff) / 2.0*SCALE
     if radius < MIN_R_SHIFT:
         # prevent it from being unrealisticly small
-        warnings.warn(
-            "dim - 2*buff <= %s, force radius to %s." % (MIN_R_SHIFT, MIN_R_SHIFT)
-        )
+        warnings.warn("dim - 2*buff <= %s, force radius to %s."\
+                %(MIN_R_SHIFT,MIN_R_SHIFT))
         radius = MIN_R_SHIFT
-    radius_square = radius**2.0
+    radius_square = radius**2.
 
     # evenly distributed within a radius, min(nx, ny)*rfrac
-    rarray = np.sqrt(radius_square * rng.rand(size))  # radius
-    tarray = rng.uniform(0.0, 2 * np.pi, size)  # theta (0, pi/nrot)
+    rarray = np.sqrt(radius_square*rng.rand(size))   # radius
+    tarray = rng.uniform(0., 2*np.pi, size)   # theta (0, pi/nrot)
 
-    shifts = np.zeros(size, dtype=[("dx", "f8"), ("dy", "f8")])
-    shifts["dx"] = rarray * np.cos(tarray)
-    shifts["dy"] = rarray * np.sin(tarray)
+    shifts = np.zeros(size, dtype=[('dx', 'f8'), ('dy', 'f8')])
+    shifts['dx'] = rarray*np.cos(tarray)
+    shifts['dy'] = rarray*np.sin(tarray)
     return shifts
 
 
@@ -313,15 +311,15 @@ def get_pair_shifts(*, rng, sep):
         arcsec
     """
 
-    shifts = np.zeros(2, dtype=[("dx", "f8"), ("dy", "f8")])
+    shifts = np.zeros(2, dtype=[('dx', 'f8'), ('dy', 'f8')])
 
     angle = rng.uniform(low=0, high=np.pi)
     shift_radius = sep / 2
 
-    xdither, ydither = SCALE * rng.uniform(low=-0.5, high=0.5, size=2)
+    xdither, ydither = SCALE*rng.uniform(low=-0.5, high=0.5, size=2)
 
-    dx1 = np.cos(angle) * shift_radius
-    dy1 = np.sin(angle) * shift_radius
+    dx1 = np.cos(angle)*shift_radius
+    dy1 = np.sin(angle)*shift_radius
     dx2 = -dx1
     dy2 = -dy1
 
@@ -331,10 +329,10 @@ def get_pair_shifts(*, rng, sep):
     dx2 += xdither
     dy2 += ydither
 
-    shifts["dx"][0] = dx1
-    shifts["dy"][0] = dy1
+    shifts['dx'][0] = dx1
+    shifts['dy'][0] = dy1
 
-    shifts["dx"][1] = dx2
-    shifts["dy"][1] = dy2
+    shifts['dx'][1] = dx2
+    shifts['dy'][1] = dy2
 
     return shifts

--- a/descwl_shear_sims/shifts.py
+++ b/descwl_shear_sims/shifts.py
@@ -273,16 +273,16 @@ def get_random_circle_shifts(*, rng, dim, buff, size):
         arcsec
     """
 
-    radius = (dim - 2*buff)/2.0*SCALE
-    if radius<2:
+    radius = (dim - 2*buff) / 2.0*SCALE
+    if radius < 2:
         # prevent it from being unrealisticly small
         warnings.warn("dim - 2*buff <= 2, force it to 2.")
-        radius=2.
-    radius_square=radius**2.
+        radius = 2.
+    radius_square = radius**2.
 
-    # evenly distributed within a radius, min(nx,ny)*rfrac
-    rarray  =   np.sqrt(radius_square*rng.rand(size))   # radius
-    tarray  =   rng.uniform(0.,2*np.pi,size)   # theta (0,pi/nrot)
+    # evenly distributed within a radius, min(nx, ny)*rfrac
+    rarray = np.sqrt(radius_square*rng.rand(size))   # radius
+    tarray = rng.uniform(0., 2*np.pi, size)   # theta (0, pi/nrot)
 
     shifts = np.zeros(size, dtype=[('dx', 'f8'), ('dy', 'f8')])
     shifts['dx'] = rarray*np.cos(tarray)

--- a/descwl_shear_sims/shifts.py
+++ b/descwl_shear_sims/shifts.py
@@ -61,7 +61,7 @@ def get_shifts(
             # area covered by objects
             if nobj is None:
                 area = ((coadd_dim - 2 * buff) * SCALE / 60) ** 2
-                nobj_mean = area * RANDOM_DENSITY
+                nobj_mean = max(area * RANDOM_DENSITY, 1)  # at least 1 gal
                 nobj = rng.poisson(nobj_mean)
 
             shifts = get_random_shifts(
@@ -76,7 +76,7 @@ def get_shifts(
             if nobj is None:
                 radius = (coadd_dim / 2.0 - buff) * SCALE / 60.0
                 area = np.pi * radius**2
-                nobj_mean = area * RANDOM_DENSITY
+                nobj_mean = max(area * RANDOM_DENSITY, 1)  # at least 1 gal
                 nobj = rng.poisson(nobj_mean)
 
             shifts = get_random_circle_shifts(

--- a/descwl_shear_sims/shifts.py
+++ b/descwl_shear_sims/shifts.py
@@ -238,8 +238,8 @@ def get_random_shifts(*, rng, dim, buff, size):
     halfwidth = (dim - 2*buff)/2.0
     if halfwidth < MIN_R_SHIFT:
         # prevent it from being unrealisticly small
-        warnings.warn("dim - 2*buff < %s, force halfwidth to %s" \
-                %(MIN_R_SHIFT, MIN_R_SHIFT))
+        warnings.warn("dim - 2*buff < %s, force halfwidth to\
+                %s" % (MIN_R_SHIFT, MIN_R_SHIFT))
         halfwidth = MIN_R_SHIFT
 
     low = -halfwidth*SCALE
@@ -278,8 +278,8 @@ def get_random_circle_shifts(*, rng, dim, buff, size):
     radius = (dim - 2*buff) / 2.0*SCALE
     if radius < MIN_R_SHIFT:
         # prevent it from being unrealisticly small
-        warnings.warn("dim - 2*buff <= %s, force radius to %s."\
-                %(MIN_R_SHIFT,MIN_R_SHIFT))
+        warnings.warn("dim - 2*buff <= %s, force radius to \
+                %s." % (MIN_R_SHIFT, MIN_R_SHIFT))
         radius = MIN_R_SHIFT
     radius_square = radius**2.
 

--- a/descwl_shear_sims/shifts.py
+++ b/descwl_shear_sims/shifts.py
@@ -1,13 +1,10 @@
 import numpy as np
-import warnings
-
 
 from .constants import (
     RANDOM_DENSITY,
     GRID_SPACING,
     HEX_SPACING,
     SCALE,
-    MIN_R_SHIFT,
 )
 
 
@@ -70,7 +67,7 @@ def get_shifts(
                 buff=buff,
                 size=nobj,
             )
-        elif layout == 'random_circle':
+        elif layout == 'random_disk':
             # randomly distributed in a circle
             # area covered by objects
             if nobj is None:
@@ -79,7 +76,7 @@ def get_shifts(
                 nobj_mean = max(area * RANDOM_DENSITY, 1)
                 nobj = rng.poisson(nobj_mean)
 
-            shifts = get_random_circle_shifts(
+            shifts = get_random_disk_shifts(
                 rng=rng,
                 dim=coadd_dim,
                 buff=buff,
@@ -215,7 +212,8 @@ def get_grid_shifts(*, rng, dim, buff, spacing):
 
 def get_random_shifts(*, rng, dim, buff, size):
     """
-    get a set of gridded shifts in a square, with random shifts at the pixel scale
+    get a set of random shifts in a square, with random shifts at the pixel
+    scale
 
     Parameters
     ----------
@@ -236,11 +234,10 @@ def get_random_shifts(*, rng, dim, buff, size):
     """
 
     halfwidth = (dim - 2*buff)/2.0
-    if halfwidth < MIN_R_SHIFT:
-        # prevent it from being unrealisticly small
-        warnings.warn("dim - 2*buff < %s, force halfwidth to\
-                %s" % (MIN_R_SHIFT, MIN_R_SHIFT))
-        halfwidth = MIN_R_SHIFT
+    if halfwidth < 0:
+        print(dim, buff, halfwidth)
+        # prevent user using a buffer that is too large
+        raise ValueError("dim - 2*buff < 0")
 
     low = -halfwidth*SCALE
     high = halfwidth*SCALE
@@ -253,8 +250,8 @@ def get_random_shifts(*, rng, dim, buff, size):
     return shifts
 
 
-def get_random_circle_shifts(*, rng, dim, buff, size):
-    """Gets a set of gridded shifts in a circle, with random shifts at the
+def get_random_disk_shifts(*, rng, dim, buff, size):
+    """Gets a set of random shifts on a disk, with random shifts at the
     pixel scale
 
     Parameters
@@ -276,11 +273,10 @@ def get_random_circle_shifts(*, rng, dim, buff, size):
     """
 
     radius = (dim - 2*buff) / 2.0*SCALE
-    if radius < MIN_R_SHIFT:
-        # prevent it from being unrealisticly small
-        warnings.warn("dim - 2*buff <= %s, force radius to \
-                %s." % (MIN_R_SHIFT, MIN_R_SHIFT))
-        radius = MIN_R_SHIFT
+    if radius < 0:
+        print(dim, buff, radius)
+        # prevent user using a buffer that is too large
+        raise ValueError("dim - 2*buff < 0")
     radius_square = radius**2.
 
     # evenly distributed within a radius, min(nx, ny)*rfrac

--- a/descwl_shear_sims/shifts.py
+++ b/descwl_shear_sims/shifts.py
@@ -73,7 +73,7 @@ def get_shifts(
             # randomly distributed in a circle
             # area covered by objects
             if nobj is None:
-                radius=(coadd_dim/2. - buff)*SCALE/60.
+                radius = (coadd_dim/2. - buff)*SCALE/60.
                 area = np.pi*radius**2
                 nobj_mean = area * RANDOM_DENSITY
                 nobj = rng.poisson(nobj_mean)
@@ -235,10 +235,10 @@ def get_random_shifts(*, rng, dim, buff, size):
     """
 
     halfwidth = (dim - 2*buff)/2.0
-    if halfwidth<2:
+    if halfwidth < 2:
         # prevent it from being unrealisticly small
         warnings.warn("dim - 2*buff < 2, force it to 2")
-        halfwidth=2.
+        halfwidth = 2.
 
     low = -halfwidth*SCALE
     high = halfwidth*SCALE
@@ -250,9 +250,10 @@ def get_random_shifts(*, rng, dim, buff, size):
 
     return shifts
 
+
 def get_random_circle_shifts(*, rng, dim, buff, size):
-    """
-    get a set of gridded shifts in a circle, with random shifts at the pixel scale
+    """Gets a set of gridded shifts in a circle, with random shifts at the
+    pixel scale
 
     Parameters
     ----------

--- a/descwl_shear_sims/shifts.py
+++ b/descwl_shear_sims/shifts.py
@@ -67,6 +67,21 @@ def get_shifts(
                 buff=buff,
                 size=nobj,
             )
+        elif layout == 'random_circle':
+            # randomly distributed in a circle
+            # area covered by objects
+            if nobj is None:
+                radius=(coadd_dim/2. - buff)*SCALE/60.
+                area = np.pi*radius**2
+                nobj_mean = area * RANDOM_DENSITY
+                nobj = rng.poisson(nobj_mean)
+
+            shifts = get_random_circle_shifts(
+                rng=rng,
+                dim=coadd_dim,
+                buff=buff,
+                size=nobj,
+            )
         elif layout == 'hex':
             shifts = get_hex_shifts(
                 rng=rng,
@@ -197,7 +212,7 @@ def get_grid_shifts(*, rng, dim, buff, spacing):
 
 def get_random_shifts(*, rng, dim, buff, size):
     """
-    get a set of gridded shifts, with random shifts at the pixel scale
+    get a set of gridded shifts in a square, with random shifts at the pixel scale
 
     Parameters
     ----------
@@ -227,6 +242,40 @@ def get_random_shifts(*, rng, dim, buff, size):
     shifts['dx'] = rng.uniform(low=low, high=high, size=size)
     shifts['dy'] = rng.uniform(low=low, high=high, size=size)
 
+    return shifts
+
+def get_random_circle_shifts(*, rng, dim, buff, size):
+    """
+    get a set of gridded shifts in a circle, with random shifts at the pixel scale
+
+    Parameters
+    ----------
+    rng: numpy.random.RandomState
+        The random number generator
+    dim: int
+        Dimensions of the final image
+    buff: int, optional
+        Buffer region where no objects will be drawn.
+    size: int
+        Number of objects to draw.
+
+    Returns
+    -------
+    shifts: array
+        Array with dx, dy offset fields for each point, in
+        arcsec
+    """
+
+    radius = (dim - 2*buff)/2.0*SCALE
+    radius_square=radius**2.
+
+    # evenly distributed within a radius, min(nx,ny)*rfrac
+    rarray  =   np.sqrt(radius_square*rng.rand(size))   # radius
+    tarray  =   rng.uniform(0.,2*np.pi,size)   # theta (0,pi/nrot)
+
+    shifts = np.zeros(size, dtype=[('dx', 'f8'), ('dy', 'f8')])
+    shifts['dx'] = rarray*np.cos(tarray)
+    shifts['dy'] = rarray*np.sin(tarray)
     return shifts
 
 

--- a/descwl_shear_sims/shifts.py
+++ b/descwl_shear_sims/shifts.py
@@ -7,6 +7,7 @@ from .constants import (
     GRID_SPACING,
     HEX_SPACING,
     SCALE,
+    MIN_R_SHIFT,
 )
 
 
@@ -235,10 +236,11 @@ def get_random_shifts(*, rng, dim, buff, size):
     """
 
     halfwidth = (dim - 2*buff)/2.0
-    if halfwidth < 2:
+    if halfwidth < MIN_R_SHIFT:
         # prevent it from being unrealisticly small
-        warnings.warn("dim - 2*buff < 2, force it to 2")
-        halfwidth = 2.
+        warnings.warn("dim - 2*buff < %s, force halfwidth to %s" \
+                %(MIN_R_SHIFT, MIN_R_SHIFT))
+        halfwidth = MIN_R_SHIFT
 
     low = -halfwidth*SCALE
     high = halfwidth*SCALE
@@ -274,10 +276,11 @@ def get_random_circle_shifts(*, rng, dim, buff, size):
     """
 
     radius = (dim - 2*buff) / 2.0*SCALE
-    if radius < 2:
+    if radius < MIN_R_SHIFT:
         # prevent it from being unrealisticly small
-        warnings.warn("dim - 2*buff <= 2, force it to 2.")
-        radius = 2.
+        warnings.warn("dim - 2*buff <= %s, force radius to %s."\
+                %(MIN_R_SHIFT,MIN_R_SHIFT))
+        radius = MIN_R_SHIFT
     radius_square = radius**2.
 
     # evenly distributed within a radius, min(nx, ny)*rfrac

--- a/descwl_shear_sims/shifts.py
+++ b/descwl_shear_sims/shifts.py
@@ -39,28 +39,28 @@ def get_shifts(
         The separation in arcseconds for layout='pair'
     """
 
-    if layout == 'pair':
+    if layout == "pair":
 
         if sep is None:
-            raise ValueError(f'send sep= for layout {layout}')
+            raise ValueError(f"send sep= for layout {layout}")
 
         shifts = get_pair_shifts(rng=rng, sep=sep)
     else:
 
         if coadd_dim is None:
-            raise ValueError(f'send coadd_dim= for layout {layout}')
+            raise ValueError(f"send coadd_dim= for layout {layout}")
 
-        if layout == 'grid':
+        if layout == "grid":
             shifts = get_grid_shifts(
                 rng=rng,
                 dim=coadd_dim,
                 buff=buff,
                 spacing=GRID_SPACING,
             )
-        elif layout == 'random':
+        elif layout == "random":
             # area covered by objects
             if nobj is None:
-                area = ((coadd_dim - 2*buff)*SCALE/60)**2
+                area = ((coadd_dim - 2 * buff) * SCALE / 60) ** 2
                 nobj_mean = area * RANDOM_DENSITY
                 nobj = rng.poisson(nobj_mean)
 
@@ -70,12 +70,12 @@ def get_shifts(
                 buff=buff,
                 size=nobj,
             )
-        elif layout == 'random_circle':
+        elif layout == "random_circle":
             # randomly distributed in a circle
             # area covered by objects
             if nobj is None:
-                radius = (coadd_dim/2. - buff)*SCALE/60.
-                area = np.pi*radius**2
+                radius = (coadd_dim / 2.0 - buff) * SCALE / 60.0
+                area = np.pi * radius**2
                 nobj_mean = area * RANDOM_DENSITY
                 nobj = rng.poisson(nobj_mean)
 
@@ -85,7 +85,7 @@ def get_shifts(
                 buff=buff,
                 size=nobj,
             )
-        elif layout == 'hex':
+        elif layout == "hex":
             shifts = get_hex_shifts(
                 rng=rng,
                 dim=coadd_dim,
@@ -121,7 +121,7 @@ def get_hex_shifts(*, rng, dim, buff, spacing):
     """
     from hexalattice.hexalattice import create_hex_grid
 
-    width = (dim - 2*buff) * SCALE
+    width = (dim - 2 * buff) * SCALE
     n_on_side = int(width / spacing) + 1
 
     nx = int(n_on_side * np.sqrt(2))
@@ -141,7 +141,7 @@ def get_hex_shifts(*, rng, dim, buff, spacing):
     upos += SCALE * rng.uniform(low=-0.5, high=0.5, size=upos.shape[0])
     vpos += SCALE * rng.uniform(low=-0.5, high=0.5, size=vpos.shape[0])
 
-    pos_bounds = (-width/2, width/2)
+    pos_bounds = (-width / 2, width / 2)
     msk = (
         (upos >= pos_bounds[0])
         & (upos <= pos_bounds[1])
@@ -152,7 +152,7 @@ def get_hex_shifts(*, rng, dim, buff, spacing):
     vpos = vpos[msk]
 
     ntot = upos.shape[0]
-    shifts = np.zeros(ntot, dtype=[('dx', 'f8'), ('dy', 'f8')])
+    shifts = np.zeros(ntot, dtype=[("dx", "f8"), ("dy", "f8")])
     shifts["dx"] = upos
     shifts["dy"] = vpos
 
@@ -181,32 +181,32 @@ def get_grid_shifts(*, rng, dim, buff, spacing):
         arcsec
     """
 
-    width = (dim - 2*buff) * SCALE
+    width = (dim - 2 * buff) * SCALE
     n_on_side = int(dim / spacing * SCALE)
 
     ntot = n_on_side**2
 
     # ix/iy are really on the sky
-    grid = spacing*(np.arange(n_on_side) - (n_on_side-1)/2)
+    grid = spacing * (np.arange(n_on_side) - (n_on_side - 1) / 2)
 
-    shifts = np.zeros(ntot, dtype=[('dx', 'f8'), ('dy', 'f8')])
+    shifts = np.zeros(ntot, dtype=[("dx", "f8"), ("dy", "f8")])
 
     i = 0
     for ix in range(n_on_side):
         for iy in range(n_on_side):
-            dx = grid[ix] + SCALE*rng.uniform(low=-0.5, high=0.5)
-            dy = grid[iy] + SCALE*rng.uniform(low=-0.5, high=0.5)
+            dx = grid[ix] + SCALE * rng.uniform(low=-0.5, high=0.5)
+            dy = grid[iy] + SCALE * rng.uniform(low=-0.5, high=0.5)
 
-            shifts['dx'][i] = dx
-            shifts['dy'][i] = dy
+            shifts["dx"][i] = dx
+            shifts["dy"][i] = dy
             i += 1
 
-    pos_bounds = (-width/2, width/2)
+    pos_bounds = (-width / 2, width / 2)
     msk = (
-        (shifts['dx'] >= pos_bounds[0])
-        & (shifts['dx'] <= pos_bounds[1])
-        & (shifts['dy'] >= pos_bounds[0])
-        & (shifts['dy'] <= pos_bounds[1])
+        (shifts["dx"] >= pos_bounds[0])
+        & (shifts["dx"] <= pos_bounds[1])
+        & (shifts["dy"] >= pos_bounds[0])
+        & (shifts["dy"] <= pos_bounds[1])
     )
     shifts = shifts[msk]
 
@@ -235,20 +235,21 @@ def get_random_shifts(*, rng, dim, buff, size):
         arcsec
     """
 
-    halfwidth = (dim - 2*buff)/2.0
+    halfwidth = (dim - 2 * buff) / 2.0
     if halfwidth < MIN_R_SHIFT:
         # prevent it from being unrealisticly small
-        warnings.warn("dim - 2*buff < %s, force halfwidth to %s" \
-                %(MIN_R_SHIFT, MIN_R_SHIFT))
+        warnings.warn(
+            "dim - 2*buff < %s, force halfwidth to %s" % (MIN_R_SHIFT, MIN_R_SHIFT)
+        )
         halfwidth = MIN_R_SHIFT
 
-    low = -halfwidth*SCALE
-    high = halfwidth*SCALE
+    low = -halfwidth * SCALE
+    high = halfwidth * SCALE
 
-    shifts = np.zeros(size, dtype=[('dx', 'f8'), ('dy', 'f8')])
+    shifts = np.zeros(size, dtype=[("dx", "f8"), ("dy", "f8")])
 
-    shifts['dx'] = rng.uniform(low=low, high=high, size=size)
-    shifts['dy'] = rng.uniform(low=low, high=high, size=size)
+    shifts["dx"] = rng.uniform(low=low, high=high, size=size)
+    shifts["dy"] = rng.uniform(low=low, high=high, size=size)
 
     return shifts
 
@@ -275,21 +276,22 @@ def get_random_circle_shifts(*, rng, dim, buff, size):
         arcsec
     """
 
-    radius = (dim - 2*buff) / 2.0*SCALE
+    radius = (dim - 2 * buff) / 2.0 * SCALE
     if radius < MIN_R_SHIFT:
         # prevent it from being unrealisticly small
-        warnings.warn("dim - 2*buff <= %s, force radius to %s."\
-                %(MIN_R_SHIFT,MIN_R_SHIFT))
+        warnings.warn(
+            "dim - 2*buff <= %s, force radius to %s." % (MIN_R_SHIFT, MIN_R_SHIFT)
+        )
         radius = MIN_R_SHIFT
-    radius_square = radius**2.
+    radius_square = radius**2.0
 
     # evenly distributed within a radius, min(nx, ny)*rfrac
-    rarray = np.sqrt(radius_square*rng.rand(size))   # radius
-    tarray = rng.uniform(0., 2*np.pi, size)   # theta (0, pi/nrot)
+    rarray = np.sqrt(radius_square * rng.rand(size))  # radius
+    tarray = rng.uniform(0.0, 2 * np.pi, size)  # theta (0, pi/nrot)
 
-    shifts = np.zeros(size, dtype=[('dx', 'f8'), ('dy', 'f8')])
-    shifts['dx'] = rarray*np.cos(tarray)
-    shifts['dy'] = rarray*np.sin(tarray)
+    shifts = np.zeros(size, dtype=[("dx", "f8"), ("dy", "f8")])
+    shifts["dx"] = rarray * np.cos(tarray)
+    shifts["dy"] = rarray * np.sin(tarray)
     return shifts
 
 
@@ -311,15 +313,15 @@ def get_pair_shifts(*, rng, sep):
         arcsec
     """
 
-    shifts = np.zeros(2, dtype=[('dx', 'f8'), ('dy', 'f8')])
+    shifts = np.zeros(2, dtype=[("dx", "f8"), ("dy", "f8")])
 
     angle = rng.uniform(low=0, high=np.pi)
     shift_radius = sep / 2
 
-    xdither, ydither = SCALE*rng.uniform(low=-0.5, high=0.5, size=2)
+    xdither, ydither = SCALE * rng.uniform(low=-0.5, high=0.5, size=2)
 
-    dx1 = np.cos(angle)*shift_radius
-    dy1 = np.sin(angle)*shift_radius
+    dx1 = np.cos(angle) * shift_radius
+    dy1 = np.sin(angle) * shift_radius
     dx2 = -dx1
     dy2 = -dy1
 
@@ -329,10 +331,10 @@ def get_pair_shifts(*, rng, sep):
     dx2 += xdither
     dy2 += ydither
 
-    shifts['dx'][0] = dx1
-    shifts['dy'][0] = dy1
+    shifts["dx"][0] = dx1
+    shifts["dy"][0] = dy1
 
-    shifts['dx'][1] = dx2
-    shifts['dy'][1] = dy2
+    shifts["dx"][1] = dx2
+    shifts["dy"][1] = dy2
 
     return shifts

--- a/descwl_shear_sims/shifts.py
+++ b/descwl_shear_sims/shifts.py
@@ -1,4 +1,6 @@
 import numpy as np
+import warnings
+
 
 from .constants import (
     RANDOM_DENSITY,
@@ -233,6 +235,10 @@ def get_random_shifts(*, rng, dim, buff, size):
     """
 
     halfwidth = (dim - 2*buff)/2.0
+    if halfwidth<2:
+        # prevent it from being unrealisticly small
+        warnings.warn("dim - 2*buff < 2, force it to 2")
+        halfwidth=2.
 
     low = -halfwidth*SCALE
     high = halfwidth*SCALE
@@ -267,6 +273,10 @@ def get_random_circle_shifts(*, rng, dim, buff, size):
     """
 
     radius = (dim - 2*buff)/2.0*SCALE
+    if radius<2:
+        # prevent it from being unrealisticly small
+        warnings.warn("dim - 2*buff <= 2, force it to 2.")
+        radius=2.
     radius_square=radius**2.
 
     # evenly distributed within a radius, min(nx,ny)*rfrac

--- a/descwl_shear_sims/sim.py
+++ b/descwl_shear_sims/sim.py
@@ -426,7 +426,7 @@ def make_exp(
     exp.setPhotoCalib(photoCalib)
 
     filter_label = afw_image.FilterLabel(band=band, physical=band)
-    exp.setFilter(filter_label)
+    exp.setFilterLabel(filter_label)
 
     exp.setPsf(dm_psf)
 

--- a/descwl_shear_sims/sim.py
+++ b/descwl_shear_sims/sim.py
@@ -421,7 +421,10 @@ def make_exp(
 
     exp = afw_image.ExposureF(masked_image)
 
-    # Prepare the frc
+    # Prepare the frc, and save it to the DM exposure
+    # It can be retrieved as follow
+    # zero_flux=  exposure.getPhotoCalib().getInstFluxAtZeroMagnitude()
+    # magz    =   np.log10(zero_flux)*2.5 # magnitude zero point
     zero_flux = 10.**(0.4*ZERO_POINT)
     photoCalib = afw_image.makePhotoCalibFromCalibZeroPoint(zero_flux)
     exp.setPhotoCalib(photoCalib)

--- a/descwl_shear_sims/sim.py
+++ b/descwl_shear_sims/sim.py
@@ -735,8 +735,8 @@ def _roate_pos(pos, theta):
         x2 (ndarray):   rotated coordiantes [x]
         y2 (ndarray):   rotated coordiantes [y]
     '''
-    x   =   pos.x
-    y   =   pos.y
-    x2  =   np.cos(theta)*x-np.sin(theta)*y
-    y2  =   np.sin(theta)*x+np.cos(theta)*y
+    x = pos.x
+    y = pos.y
+    x2 = np.cos(theta)*x-np.sin(theta)*y
+    y2 = np.sin(theta)*x+np.cos(theta)*y
     return galsim.PositionD(x=x2, y=y2)

--- a/descwl_shear_sims/sim.py
+++ b/descwl_shear_sims/sim.py
@@ -145,7 +145,7 @@ def make_sim(
 
     band_data = {}
     bright_info = []
-    se_wcs  =   []
+    se_wcs = []
     for band in bands:
 
         survey = get_survey(gal_type=galaxy_catalog.gal_type, band=band)
@@ -199,7 +199,6 @@ def make_sim(
                 bright_info += this_bright_info
                 se_wcs.append(this_se_wcs)
 
-
             if galaxy_catalog.gal_type == 'wldeblend':
                 rescale_wldeblend_exp(
                     survey=survey.descwl_survey,
@@ -227,7 +226,7 @@ def make_sim(
         'coadd_dims': (coadd_dim, )*2,
         'coadd_bbox': coadd_bbox,
         'bright_info': bright_info,
-        'se_wcs':   se_wcs,
+        'se_wcs': se_wcs,
     }
 
 
@@ -422,7 +421,7 @@ def make_exp(
     exp = afw_image.ExposureF(masked_image)
 
     # Prepare the frc
-    zero_flux=10.**(0.4*ZERO_POINT)
+    zero_flux = 10.**(0.4*ZERO_POINT)
     photoCalib = afw_image.makePhotoCalibFromCalibZeroPoint(zero_flux)
     exp.setPhotoCalib(photoCalib)
 
@@ -456,16 +455,16 @@ def _draw_objects(
     for obj, shift in zip(objlist, shifts):
 
         if theta0 is not None:
-            ang     =   theta0*galsim.radians
+            ang = theta0*galsim.radians
             # rotation on intrinsic galaxies comes before shear distortion
-            obj     =   obj.rotate(ang)
-            shift   =   _roate_pos(shift,theta0)
+            obj = obj.rotate(ang)
+            shift = _roate_pos(shift, theta0)
 
         if shear is not None:
             obj = obj.shear(shear)
             shift = shift.shear(shear)
 
-        # Deproject from u,v onto sphere.  Then use wcs to get to image pos.
+        # Deproject from u,v onto sphere. Then use wcs to get to image pos.
         world_pos = coadd_bbox_cen_gs_skypos.deproject(
             shift.x * galsim.arcsec,
             shift.y * galsim.arcsec,
@@ -725,8 +724,10 @@ def get_bright_info_struct():
     ]
     return np.zeros(1, dtype=dt)
 
-def _roate_pos(pos,theta):
+
+def _roate_pos(pos, theta):
     '''Rotates coordinates by an angle theta
+
     Args:
         pos (PositionD):a galsim position
         theta (float):  rotation angle [rads]

--- a/descwl_shear_sims/sim.py
+++ b/descwl_shear_sims/sim.py
@@ -332,7 +332,9 @@ def make_exp(
 
     shear = galsim.Shear(g1=g1, g2=g2)
     dims = [dim]*2
-    cen = (np.array(dims)-1)/2
+    # I think Galsim uses 1 offset. An array with length=dim=5
+    # The center is at 3=(5+1)/2
+    cen = (np.array(dims)+1)/2
 
     se_origin = galsim.PositionD(x=cen[1], y=cen[0])
     if dither:

--- a/descwl_shear_sims/sim.py
+++ b/descwl_shear_sims/sim.py
@@ -118,7 +118,8 @@ def make_sim(
         Draw method for galsim objects, default 'auto'.  Set to
         'phot' to get poisson noise.  Note this is much slower.
     theta0: float
-        The rotation angle of the exposure, in units of radians
+        rotation angle of intrinsic galaxies and positions [for ring test],
+        default 0, in units of radians
 
     Returns
     -------

--- a/descwl_shear_sims/sim.py
+++ b/descwl_shear_sims/sim.py
@@ -416,7 +416,7 @@ def make_exp(
     exp = afw_image.ExposureF(masked_image)
 
     filter_label = afw_image.FilterLabel(band=band, physical=band)
-    exp.setFilterLabel(filter_label)
+    exp.setFilter(filter_label)
 
     exp.setPsf(dm_psf)
 

--- a/descwl_shear_sims/stars.py
+++ b/descwl_shear_sims/stars.py
@@ -44,7 +44,7 @@ def get_star_config(config=None):
     return out_config
 
 
-def make_star_catalog(rng, coadd_dim, buff=0, star_config=None):
+def make_star_catalog(rng, coadd_dim, buff=0, star_config=None, layout='random'):
     """
     Creat a StarCatalog
 
@@ -73,6 +73,7 @@ def make_star_catalog(rng, coadd_dim, buff=0, star_config=None):
         density=star_config['density'],
         min_density=star_config['min_density'],
         max_density=star_config['max_density'],
+        layout=layout,
     )
 
 

--- a/descwl_shear_sims/stars.py
+++ b/descwl_shear_sims/stars.py
@@ -95,6 +95,8 @@ class StarCatalog(object):
     density: float, optional
         Optional density for catalog, if not sent the density is variable and
         drawn from the expected galactic density
+    layout: string
+        'random' or 'random_circle'
     """
     def __init__(
         self, *, rng, coadd_dim,
@@ -102,6 +104,7 @@ class StarCatalog(object):
         min_density=DEFAULT_MIN_STAR_DENSITY,
         max_density=DEFAULT_MAX_STAR_DENSITY,
         density=DEFAULT_DENSITY,
+        layout='random',
     ):
         self.rng = rng
 
@@ -116,17 +119,27 @@ class StarCatalog(object):
         else:
             density_mean = density
 
+        if layout=='random':
+            # this layout is random in a square
+            area = ((coadd_dim - 2*buff)*SCALE/60)**2
+        elif layout=='random_circle':
+            # this layout is random in a circle
+            radius=(coadd_dim/2. - buff)*SCALE/60
+            area = np.pi*radius**2
+            del radius
+        else:
+            raise ValueError("layout can only be 'random' or 'random_circle' for wldeblend")
+
         area = ((coadd_dim - 2*buff)*SCALE/60)**2
         nobj_mean = area * density_mean
         nobj = rng.poisson(nobj_mean)
-
         self.density = nobj/area
 
         self.shifts_array = get_shifts(
             rng=rng,
             coadd_dim=coadd_dim,
             buff=buff,
-            layout="random",
+            layout=layout,
             nobj=nobj,
         )
 

--- a/descwl_shear_sims/stars.py
+++ b/descwl_shear_sims/stars.py
@@ -96,7 +96,7 @@ class StarCatalog(object):
         Optional density for catalog, if not sent the density is variable and
         drawn from the expected galactic density
     layout: string
-        'random' or 'random_circle'
+        'random' or 'random_disk'
     """
     def __init__(
         self, *, rng, coadd_dim,
@@ -122,13 +122,13 @@ class StarCatalog(object):
         if layout == 'random':
             # this layout is random in a square
             area = ((coadd_dim - 2*buff)*SCALE/60)**2
-        elif layout == 'random_circle':
+        elif layout == 'random_disk':
             # this layout is random in a circle
             radius = (coadd_dim/2. - buff)*SCALE/60
             area = np.pi*radius**2
             del radius
         else:
-            raise ValueError("layout can only be 'random' or 'random_circle' \
+            raise ValueError("layout can only be 'random' or 'random_disk' \
                     for wldeblend")
 
         area = ((coadd_dim - 2*buff)*SCALE/60)**2

--- a/descwl_shear_sims/stars.py
+++ b/descwl_shear_sims/stars.py
@@ -119,16 +119,17 @@ class StarCatalog(object):
         else:
             density_mean = density
 
-        if layout=='random':
+        if layout == 'random':
             # this layout is random in a square
             area = ((coadd_dim - 2*buff)*SCALE/60)**2
-        elif layout=='random_circle':
+        elif layout == 'random_circle':
             # this layout is random in a circle
-            radius=(coadd_dim/2. - buff)*SCALE/60
+            radius = (coadd_dim/2. - buff)*SCALE/60
             area = np.pi*radius**2
             del radius
         else:
-            raise ValueError("layout can only be 'random' or 'random_circle' for wldeblend")
+            raise ValueError("layout can only be 'random' or 'random_circle' \
+                    for wldeblend")
 
         area = ((coadd_dim - 2*buff)*SCALE/60)**2
         nobj_mean = area * density_mean

--- a/descwl_shear_sims/surveys.py
+++ b/descwl_shear_sims/surveys.py
@@ -70,6 +70,8 @@ def get_wldeblend_rescale_fac(survey):
     """
     s_zp = survey.zero_point
     s_et = survey.exposure_time
+    # following
+    # https://github.com/LSSTDESC/WeakLensingDeblending/blob/228c6655d63de9edd9bf2c8530f99199ee47fc5e/descwl/survey.py#L143
     return 10.0**(0.4*(ZERO_POINT - 24.0))/s_zp/s_et
 
 

--- a/descwl_shear_sims/tests/test_sim.py
+++ b/descwl_shear_sims/tests/test_sim.py
@@ -245,7 +245,7 @@ def test_sim_epochs(epochs_per_band):
         assert len(band_data[band]) == epochs_per_band
 
 
-@pytest.mark.parametrize("layout", ("grid", "random", "hex"))
+@pytest.mark.parametrize("layout", ("grid", "random", "random_disk", "hex"))
 def test_sim_layout(layout):
     seed = 7421
     coadd_dim = 201
@@ -333,6 +333,7 @@ def test_sim_wldeblend():
         gal_type="wldeblend",
         coadd_dim=coadd_dim,
         buff=30,
+        layout="random",
     )
 
     psf = make_fixed_psf(psf_type="moffat")
@@ -372,6 +373,7 @@ def test_sim_stars(density, min_density, max_density):
             gal_type="wldeblend",
             coadd_dim=coadd_dim,
             buff=buff,
+            layout="random",
         )
         assert len(galaxy_catalog) == galaxy_catalog.shifts_array.size
 
@@ -434,6 +436,7 @@ def test_sim_star_bleeds():
         gal_type="wldeblend",
         coadd_dim=coadd_dim,
         buff=buff,
+        layout="random",
     )
 
     star_catalog = StarCatalog(

--- a/descwl_shear_sims/tests/test_sim_center.py
+++ b/descwl_shear_sims/tests/test_sim_center.py
@@ -7,9 +7,7 @@ import pytest
 import galsim
 import numpy as np
 from descwl_shear_sims.sim import make_sim
-from descwl_shear_sims.galaxies import (
-    WLDeblendGalaxyCatalog,
-)  # one of the galaxy catalog classes
+from descwl_shear_sims.galaxies import make_galaxy_catalog
 from descwl_shear_sims.psfs import make_fixed_psf  # for making a power spectrum PSF
 
 
@@ -34,8 +32,9 @@ def test_sim_center(ran_seed):
     psf = make_fixed_psf(psf_type="moffat")
 
     # galaxy catalog; you can make your own
-    galaxy_catalog = WLDeblendGalaxyCatalog(
+    galaxy_catalog = make_galaxy_catalog(
         rng=rng,
+        gal_type="fixed",
         coadd_dim=coadd_dim,
         buff=buff,
         layout="random_circle",

--- a/descwl_shear_sims/tests/test_sim_center.py
+++ b/descwl_shear_sims/tests/test_sim_center.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+"""
+This is the unit test to make sure that the simulated images are centerred at
+(dim-1)/2.
+"""
+import pytest
+import galsim
+import numpy as np
+from descwl_shear_sims.sim import make_sim
+from descwl_shear_sims.galaxies import (
+    WLDeblendGalaxyCatalog,
+)  # one of the galaxy catalog classes
+from descwl_shear_sims.psfs import make_fixed_psf  # for making a power spectrum PSF
+
+
+@pytest.mark.parametrize("ran_seed", [0, 1, 2])
+def test_sim_center(ran_seed):
+    """Tests to make sure the center of a simulated galaxy is at image center
+    if offset is zero.
+    """
+    rng = np.random.RandomState(ran_seed)
+    args = {
+        "rotate": False,
+        "dither": False,
+        "cosmic_rays": False,
+        "bad_columns": False,
+        "star_bleeds": False,
+        "star_catalog": None,
+    }
+    band_list = ["i"]
+    # make simulation that has zero offset since buff>(coadd_dim+10)/2.
+    coadd_dim = 53
+    buff = 40
+    psf = make_fixed_psf(psf_type="moffat")
+
+    # galaxy catalog; you can make your own
+    galaxy_catalog = WLDeblendGalaxyCatalog(
+        rng=rng,
+        coadd_dim=coadd_dim,
+        buff=buff,
+        layout="random_circle",
+    )
+
+    sim_data = make_sim(
+        rng=rng,
+        galaxy_catalog=galaxy_catalog,
+        coadd_dim=coadd_dim,
+        g1=0.02,
+        g2=0.00,
+        psf=psf,
+        bands=band_list,
+        noise_factor=0.0,
+        theta0=0.0,
+        **args
+    )
+    img_array = sim_data["band_data"][band_list[0]][0].getImage().getArray()
+    out_dim = img_array.shape[0]
+    # +10 is to avoid downstream (what is that?)
+    assert out_dim == coadd_dim + 10, (
+        "The length of the output image should \
+            be %d"
+        % out_dim
+    )
+    img = galsim.ImageF(img_array)
+    moments = galsim.hsm.FindAdaptiveMom(img)
+    offset = moments.image_bounds.center - moments.moments_centroid
+    np.testing.assert_almost_equal(offset.x, 0.0, 5)
+    np.testing.assert_almost_equal(offset.y, 0.0, 5)
+
+    return
+
+
+if __name__ == "__main__":
+    test_sim_center(0)

--- a/descwl_shear_sims/tests/test_sim_center.py
+++ b/descwl_shear_sims/tests/test_sim_center.py
@@ -26,9 +26,9 @@ def test_sim_center(ran_seed):
         "star_catalog": None,
     }
     band_list = ["i"]
-    # make simulation that has zero offset since buff>(coadd_dim+10)/2.
-    coadd_dim = 53
-    buff = 40
+    # make simulation that has zero offset since buff = coadd_dim / 2
+    coadd_dim = 60
+    buff = 30
     psf = make_fixed_psf(psf_type="moffat")
 
     # galaxy catalog; you can make your own
@@ -37,7 +37,7 @@ def test_sim_center(ran_seed):
         gal_type="fixed",
         coadd_dim=coadd_dim,
         buff=buff,
-        layout="random_circle",
+        layout="random_disk",
     )
 
     sim_data = make_sim(
@@ -62,7 +62,7 @@ def test_sim_center(ran_seed):
     )
     img = galsim.ImageF(img_array)
     moments = galsim.hsm.FindAdaptiveMom(img)
-    offset = moments.image_bounds.center - moments.moments_centroid
+    offset = galsim.BoundsD(moments.image_bounds).center - moments.moments_centroid
     np.testing.assert_almost_equal(offset.x, 0.0, 5)
     np.testing.assert_almost_equal(offset.y, 0.0, 5)
 

--- a/examples/example_ring_tests.py
+++ b/examples/example_ring_tests.py
@@ -49,7 +49,8 @@ elif itest==1:
         rng=rng,
         coadd_dim=coadd_dim,
         buff=buff,
-        density=(ifield%1000)/10+1
+        density=(ifield%1000)/10+1,
+        layout='random_circle',
     )
 elif itest==2:
     args={
@@ -62,6 +63,7 @@ elif itest==2:
         coadd_dim=coadd_dim,
         buff=buff,
         density=(ifield%1000)/10+1,
+        layout='random_circle',
     )
 else:
     raise ValueError('itest must be 0, 1 or 2 !!!')
@@ -74,6 +76,7 @@ galaxy_catalog = WLDeblendGalaxyCatalog(
     rng=rng,
     coadd_dim=coadd_dim,
     buff=buff,
+    layout='random_circle',
 )
 psf = make_ps_psf(rng=rng, dim=se_dim)
 

--- a/examples/example_ring_tests.py
+++ b/examples/example_ring_tests.py
@@ -47,7 +47,7 @@ elif itest==1:
         coadd_dim=coadd_dim,
         buff=buff,
         density=(ifield%1000)/10+1,
-        layout='random_circle',
+        layout='random_disk',
     )
 elif itest==2:
     args={
@@ -60,7 +60,7 @@ elif itest==2:
         coadd_dim=coadd_dim,
         buff=buff,
         density=(ifield%1000)/10+1,
-        layout='random_circle',
+        layout='random_disk',
     )
 else:
     raise ValueError('itest must be 0, 1 or 2 !!!')
@@ -73,7 +73,7 @@ galaxy_catalog = WLDeblendGalaxyCatalog(
     rng=rng,
     coadd_dim=coadd_dim,
     buff=buff,
-    layout='random_circle',
+    layout='random_disk',
 )
 
 

--- a/examples/example_ring_tests.py
+++ b/examples/example_ring_tests.py
@@ -1,0 +1,100 @@
+"""
+simple example with ring test (rotating intrinsic galaxies)
+"""
+import os
+import numpy as np
+from descwl_shear_sims.sim import make_sim
+from descwl_shear_sims.galaxies import WLDeblendGalaxyCatalog  # one of the galaxy catalog classes
+from descwl_shear_sims.stars import StarCatalog  # star catalog class
+from descwl_shear_sims.psfs import make_ps_psf  # for making a power spectrum PSF
+from descwl_shear_sims.sim import get_se_dim  # convert coadd dims to SE dims
+
+
+ifield=0
+itest=0
+
+rng = np.random.RandomState(ifield)
+
+coadd_dim = 400
+buff   = 50
+rotate = False
+dither = False
+
+# this is the single epoch image sized used by the sim, we need
+# it for the power spectrum psf
+se_dim = get_se_dim(coadd_dim=coadd_dim, rotate=rotate, dither=dither)
+
+
+nrot= 4
+g1_list=[0.02,-0.02]
+band_list=['r', 'i', 'z']
+rot_list=[np.pi/nrot*i for i in range(nrot)]
+nshear=len(g1_list)
+
+
+if itest==0:
+    args={
+            'cosmic_rays':False,
+            'bad_columns':False,
+            'star_bleeds':False,
+    }
+    star_catalog=None
+elif itest==1:
+    args={
+            'cosmic_rays':False,
+            'bad_columns':False,
+            'star_bleeds':False,
+    }
+    star_catalog = StarCatalog(
+        rng=rng,
+        coadd_dim=coadd_dim,
+        buff=buff,
+        density=(ifield%1000)/10+1
+    )
+elif itest==2:
+    args={
+            'cosmic_rays':True,
+            'bad_columns':True,
+            'star_bleeds':True,
+    }
+    star_catalog = StarCatalog(
+        rng=rng,
+        coadd_dim=coadd_dim,
+        buff=buff,
+        density=(ifield%1000)/10+1,
+    )
+else:
+    raise ValueError('itest must be 0, 1 or 2 !!!')
+
+os.makedirs('outputs/test%d' %itest,exist_ok=True)
+
+
+# galaxy catalog; you can make your own
+galaxy_catalog = WLDeblendGalaxyCatalog(
+    rng=rng,
+    coadd_dim=coadd_dim,
+    buff=buff,
+)
+psf = make_ps_psf(rng=rng, dim=se_dim)
+
+for irot in range(nrot):
+    for ishear in range(nshear):
+        sim_data = make_sim(
+            rng=rng,
+            galaxy_catalog=galaxy_catalog,
+            star_catalog=star_catalog,
+            coadd_dim=coadd_dim,
+            g1=g1_list[ishear],
+            g2=0.00,
+            psf=psf,
+            dither=dither,
+            rotate=rotate,
+            bands=band_list,
+            noise_factor=0.,
+            theta0=rot_list[irot],
+            **args
+        )
+        for bb in band_list:
+            sim_data['band_data'][bb][0].\
+                writeFits('outputs/test%d/field%04d_shear%d_rot%d_%s.fits' \
+                %(itest,ifield,ishear,irot,bb))

--- a/examples/example_ring_tests.py
+++ b/examples/example_ring_tests.py
@@ -4,10 +4,10 @@ simple example with ring test (rotating intrinsic galaxies)
 import os
 import numpy as np
 from descwl_shear_sims.sim import make_sim
-from descwl_shear_sims.galaxies import WLDeblendGalaxyCatalog  # one of the galaxy catalog classes
-from descwl_shear_sims.stars import StarCatalog  # star catalog class
-from descwl_shear_sims.psfs import make_ps_psf  # for making a power spectrum PSF
-from descwl_shear_sims.sim import get_se_dim  # convert coadd dims to SE dims
+from descwl_shear_sims.galaxies import WLDeblendGalaxyCatalog   # one of the galaxy catalog classes
+from descwl_shear_sims.stars import StarCatalog                 # star catalog class
+from descwl_shear_sims.psfs import make_ps_psf,make_fixed_psf   # for making a power spectrum PSF
+from descwl_shear_sims.sim import get_se_dim                    # convert coadd dims to SE dims
 
 
 ifield=0
@@ -19,10 +19,8 @@ coadd_dim = 400
 buff   = 50
 rotate = False
 dither = False
+psf_vary=False
 
-# this is the single epoch image sized used by the sim, we need
-# it for the power spectrum psf
-se_dim = get_se_dim(coadd_dim=coadd_dim, rotate=rotate, dither=dither)
 
 
 nrot= 4
@@ -78,7 +76,16 @@ galaxy_catalog = WLDeblendGalaxyCatalog(
     buff=buff,
     layout='random_circle',
 )
-psf = make_ps_psf(rng=rng, dim=se_dim)
+
+
+if psf_vary:
+    # this is the single epoch image sized used by the sim, we need
+    # it for the power spectrum psf
+    se_dim = get_se_dim(coadd_dim=coadd_dim, rotate=rotate, dither=dither)
+    psf = make_ps_psf(rng=rng, dim=se_dim)
+else:
+    psf = make_fixed_psf(psf_type='moffat')
+
 
 for irot in range(nrot):
     for ishear in range(nshear):

--- a/examples/example_ring_tests.py
+++ b/examples/example_ring_tests.py
@@ -22,7 +22,6 @@ dither = False
 psf_vary=False
 
 
-
 nrot= 4
 g1_list=[0.02,-0.02]
 band_list=['r', 'i', 'z']

--- a/examples/example_wldeblend_stars.py
+++ b/examples/example_wldeblend_stars.py
@@ -37,6 +37,7 @@ def go():
         gal_type='wldeblend',
         coadd_dim=coadd_dim,
         buff=buff,
+        layout="random",
     )
 
     # stars with the high density so we get some

--- a/shear_meas_tests/test_shear_meas_ringtest_metacal.py
+++ b/shear_meas_tests/test_shear_meas_ringtest_metacal.py
@@ -1,0 +1,222 @@
+import ngmix
+import pytest
+import numpy as np
+
+from descwl_shear_sims.sim import make_sim
+from descwl_shear_sims.galaxies import make_galaxy_catalog
+from descwl_shear_sims.psfs import make_fixed_psf  # for making a power spectrum PSF
+from descwl_shear_sims.constants import SCALE
+
+
+rng0 = np.random.RandomState(1024)
+# We will measure moments with a fixed gaussian weight function
+weight_fwhm = 1.2
+fitter = ngmix.gaussmom.GaussMom(fwhm=weight_fwhm)
+psf_fitter = ngmix.gaussmom.GaussMom(fwhm=weight_fwhm)
+
+# these "runners" run the measurement code on observations
+psf_runner = ngmix.runners.PSFRunner(fitter=psf_fitter)
+runner = ngmix.runners.Runner(fitter=fitter)
+
+boot = ngmix.metacal.MetacalBootstrapper(
+    runner=runner,
+    psf_runner=psf_runner,
+    rng=rng0,
+    psf="gauss",
+    types=["noshear", "1p", "1m"],
+)
+
+
+def make_desc_sim(ran_seed, psf):
+    """Makes 4 desc images using descwl_shear_sims, each of the image is a
+    rotated version of the same intrinsic galaxy (then sheared and smeared).
+
+    Parameters:
+        ran_seed (int):     random seed
+        psf (galsim.PSF):   Galsim PSF
+    """
+
+    rng = np.random.RandomState(ran_seed)
+    args = {
+        "rotate": False,
+        "dither": False,
+        "cosmic_rays": False,
+        "bad_columns": False,
+        "star_bleeds": False,
+        "star_catalog": None,
+    }
+    band_list = ["i"]
+    # make simulation that has zero offset since buff > (coadd_dim+10) / 2.
+    coadd_dim = 53
+    buff = 25
+
+    # galaxy catalog; you can make your own
+    galaxy_catalog = make_galaxy_catalog(
+        rng=rng,
+        gal_type="fixed",
+        coadd_dim=coadd_dim,
+        buff=buff,
+        layout="random_circle",
+    )
+
+    nrot = 4
+    rot_list = [np.pi / nrot * i for i in range(nrot)]
+    img_array_list = []
+    for theta0 in rot_list:
+        sim_data = make_sim(
+            rng=rng,
+            galaxy_catalog=galaxy_catalog,
+            coadd_dim=coadd_dim,
+            g1=0.02,
+            g2=0.00,
+            psf=psf,
+            bands=band_list,
+            noise_factor=0.0,
+            theta0=theta0,
+            **args
+        )
+        img_array_list.append(
+            sim_data["band_data"][band_list[0]][0].getImage().getArray()
+        )
+    return img_array_list
+
+
+def make_ngmix_obs(gal_array, psf_array):
+    """Transforms to Ngmix data
+
+    Parameters:
+        gal_array (ndarray):    galaxy array
+        psf_array (ndarray):    psf array
+    """
+
+    cen = (np.array(gal_array.shape) - 1.0) / 2.0
+    psf_cen = (np.array(psf_array.shape) - 1.0) / 2.0
+    jacobian = ngmix.DiagonalJacobian(
+        row=cen[0],
+        col=cen[1],
+        scale=SCALE,
+    )
+    psf_jacobian = ngmix.DiagonalJacobian(
+        row=psf_cen[0],
+        col=psf_cen[1],
+        scale=SCALE,
+    )
+
+    gal_noise = 1e-10
+    psf_noise = 1e-10
+    wt = np.ones_like(gal_array) / gal_noise**2.0
+    psf_wt = np.ones_like(psf_array) / psf_noise**2.0
+
+    psf_obs = ngmix.Observation(
+        psf_array,
+        weight=psf_wt,
+        jacobian=psf_jacobian,
+    )
+    obs = ngmix.Observation(
+        gal_array,
+        weight=wt,
+        jacobian=jacobian,
+        psf=psf_obs,
+    )
+    return obs
+
+
+def select(data, shear_type):
+    """Selects the data by shear type and size
+    Parameters
+    ----------
+    data: array
+        The array with fields shear_type and T
+    shear_type: str
+        e.g. 'noshear', '1p', etc.
+    Returns
+    -------
+    array of indices
+    """
+
+    (w,) = np.where((data["flags"] == 0) & (data["shear_type"] == shear_type))
+    return w
+
+
+def make_struct(res, obs, shear_type):
+    """Makes the data structure
+
+    Parameters:
+    res: dict
+        With keys 's2n', 'e', and 'T'
+    obs: ngmix.Observation
+        The observation for this shear type
+    shear_type: str
+        The shear type
+    Returns:
+        1-element array with fields
+    """
+    dt = [
+        ("flags", "i4"),
+        ("shear_type", "U7"),
+        ("s2n", "f8"),
+        ("g", "f8", 2),
+        ("T", "f8"),
+        ("Tpsf", "f8"),
+    ]
+    data = np.zeros(1, dtype=dt)
+    data["shear_type"] = shear_type
+    data["flags"] = res["flags"]
+    if res["flags"] == 0:
+        # data['s2n'] = res['s2n']
+        data["s2n"] = res["s2n"]
+        # for moments we are actually measureing e, the elliptity
+        data["g"] = res["e"]
+        data["T"] = res["T"]
+    else:
+        data["s2n"] = np.nan
+        data["g"] = np.nan
+        data["T"] = np.nan
+        data["Tpsf"] = np.nan
+
+        # we only have one epoch and band, so we can get the psf T from the
+        # observation rather than averaging over epochs/bands
+        data["Tpsf"] = obs.psf.meta["result"]["T"]
+    return data
+
+
+@pytest.mark.parametrize("ran_seed", [0, 1, 2, 3])
+def test_sim_center(ran_seed):
+    """Tests to 4 x 45 degree rotations cancel the shape noise in shear
+    estimation
+    """
+
+    psf = make_fixed_psf(psf_type="moffat")
+    gal_array_list = make_desc_sim(ran_seed, psf)
+    psf_array = psf.drawImage(scale=SCALE).array
+    outputs = []
+    for gal_array in gal_array_list:
+        obs = make_ngmix_obs(gal_array, psf_array)
+        resdict, obsdict = boot.go(obs)
+        for stype, sres in resdict.items():
+            st = make_struct(res=sres, obs=obsdict[stype], shear_type=stype)
+            outputs.append(st)
+        del obs, resdict, obsdict
+
+    outputs = np.hstack(outputs)
+
+    w = select(data=outputs, shear_type="noshear")
+    w_1p = select(data=outputs, shear_type="1p")
+    w_1m = select(data=outputs, shear_type="1m")
+    g_1p = outputs["g"][w_1p, 0].mean()
+    g_1m = outputs["g"][w_1m, 0].mean()
+    R11 = (g_1p - g_1m) / 0.02
+
+    g = outputs["g"][w].mean(axis=0)
+    shear = g / R11
+
+    # assert the difference between the measured shear and the input shear is
+    # less than 1e-5
+    np.testing.assert_almost_equal(shear[0] - 0.02, 0.0, 5)
+    np.testing.assert_almost_equal(shear[1], 0.0, 5)
+
+    return
+
+
+if __name__ == "__main__":
+    test_sim_center(0)

--- a/shear_meas_tests/test_shear_meas_ringtest_metacal.py
+++ b/shear_meas_tests/test_shear_meas_ringtest_metacal.py
@@ -57,7 +57,7 @@ def make_desc_sim(ran_seed, psf):
         gal_type="fixed",
         coadd_dim=coadd_dim,
         buff=buff,
-        layout="random_circle",
+        layout="random_disk",
     )
 
     nrot = 4

--- a/shear_meas_tests/test_shear_meas_ringtest_metacal.py
+++ b/shear_meas_tests/test_shear_meas_ringtest_metacal.py
@@ -46,7 +46,8 @@ def make_desc_sim(ran_seed, psf):
         "star_catalog": None,
     }
     band_list = ["i"]
-    # make simulation that has zero offset since buff > (coadd_dim+10) / 2.
+    # make simulations, the galaxies have 0~1.5 pixel offsets
+    # (53-25*2) / 2. = 1.5
     coadd_dim = 53
     buff = 25
 


### PR DESCRIPTION
1. Enable ring test to reduce error on additive bias (4x 45 degree pairs);
2. Enable dumping PSF object to disk (for reuse);
3. record magnitude zero point in the output exposures;
4. The center of the image was at ndim/2-1 for an image with indexing 1,2..ndim (that is the Gaism indexing). Now fix it to ndim/2+1. For example, a length 3 array, with indexing 1,2,3, the center should be at 2=(3+1)/2.