### PR TITLE
Maintenance update after recent changes in lsst.afw.image.exposure._exposure.ExposureF

### DIFF
--- a/.github/workflows/shear_meas_tests.yml
+++ b/.github/workflows/shear_meas_tests.yml
@@ -12,7 +12,7 @@ jobs:
     name: shear-meas-tests
     strategy:
       matrix:
-        pyver: [3.8]
+        pyver: ["3.10"]
 
     runs-on: "ubuntu-latest"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     name: tests
     strategy:
       matrix:
-        pyver: [3.8]
+        pyver: [3.9]
 
     runs-on: "ubuntu-latest"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     name: tests
     strategy:
       matrix:
-        pyver: [3.10]
+        pyver: ["3.10"]
 
     runs-on: "ubuntu-latest"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     name: tests
     strategy:
       matrix:
-        pyver: [3.9]
+        pyver: [3.10]
 
     runs-on: "ubuntu-latest"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,12 @@ jobs:
 
           pip install --no-deps -e .
 
+      - name: env and package versions
+        shell: bash -l {0}
+        run: |
+          conda info
+          conda list
+
       - name: lint
         shell: bash -l {0}
         run: |

--- a/descwl_shear_sims/sim.py
+++ b/descwl_shear_sims/sim.py
@@ -430,7 +430,7 @@ def make_exp(
     exp.setPhotoCalib(photoCalib)
 
     filter_label = afw_image.FilterLabel(band=band, physical=band)
-    exp.setFilterLabel(filter_label)
+    exp.setFilter(filter_label)
 
     exp.setPsf(dm_psf)
 


### PR DESCRIPTION
From a clean/fresh install of the conda environment recommended for this package, I'm getting an error at this line:
https://github.com/LSSTDESC/descwl-shear-sims/blob/0b1844428f673f169be4e9e76f2fef08e6ab7df4/descwl_shear_sims/sim.py#L433

And digging through the afw code, it looks like that method has been removed by Eli back in October:
https://github.com/lsst/afw/commit/ae33f7b6e9a0437c374e81655991ba9bdfd3feb8

This PR simply proposes to use the .setFilter method instead