### PR TITLE
Enable option for using `making_coadd_dm_wcs_simple` in `make_sim`

### DIFF
--- a/descwl_shear_sims/sim.py
+++ b/descwl_shear_sims/sim.py
@@ -136,11 +136,11 @@ def make_sim(
         the final coadd WCS and deteremines some properties of
         the single epoch images.
     simple_coadd_bbox: optional, bool. Default False
-        If set to True, the coadd bbox is a simple box bounded by 
-        (0,0,coadd_dim,coadd_dim), and the coadd and SE WCS have the same 
-        world origin. If set to False, the coadd bbox is embeded in a larger 
-        box bounded by (xoff, yoff, xoff+coadd_dim, yoff+coadd_dim) and 
-        the SE WCS has a different world origin as coadd WCS.  
+        If set to True, the coadd bbox is a simple box bounded by
+        (0,0,coadd_dim,coadd_dim), and the coadd and SE WCS have the same
+        world origin. If set to False, the coadd bbox is embeded in a larger
+        box bounded by (xoff, yoff, xoff+coadd_dim, yoff+coadd_dim) and
+        the SE WCS has a different world origin as coadd WCS.
     draw_noise: optional, bool
         Whether draw image noise
 

--- a/descwl_shear_sims/sim.py
+++ b/descwl_shear_sims/sim.py
@@ -273,6 +273,7 @@ def make_sim(
                 calib_mag_zero=calib_mag_zero,
                 draw_noise=draw_noise,
                 indexes=lists["indexes"],
+                simple_coadd_bbox=simple_coadd_bbox,
             )
             if epoch == 0:
                 bright_info += this_bright_info
@@ -353,6 +354,7 @@ def make_exp(
     calib_mag_zero=ZERO_POINT,
     draw_noise=True,
     indexes=None,
+    simple_coadd_bbox=False,
 ):
     """
     Make an SEObs
@@ -419,6 +421,9 @@ def make_exp(
         magnitude zero point after calibration
     indexes: list
         list of indexes in the input galaxy catalog
+    simple_coadd_bbox: optional, bool. Default False
+        If set to True, the SE WCS sky origin is forced to be WORLD_ORIGIN,
+        which is consistent with the simple coadd wcs.
     Returns
     -------
     exp: lsst.afw.image.ExposureF

--- a/descwl_shear_sims/sim.py
+++ b/descwl_shear_sims/sim.py
@@ -17,7 +17,7 @@ from .masking import (
 )
 from .objlists import get_objlist
 from .psfs import make_dm_psf
-from .wcs import make_wcs, make_dm_wcs, make_coadd_dm_wcs
+from .wcs import make_wcs, make_dm_wcs, make_coadd_dm_wcs, make_coadd_dm_wcs_simple
 from .shear import ShearConstant
 
 
@@ -78,6 +78,7 @@ def make_sim(
     g1=None,
     g2=None,
     coadd_dim=None,
+    simple_coadd_bbox=False,
     draw_noise=True,
 ):
     """
@@ -134,6 +135,12 @@ def make_sim(
         Dimensions for planned final coadd.  This is used for generating
         the final coadd WCS and deteremines some properties of
         the single epoch images.
+    simple_coadd_bbox: optional, bool. Default False
+        If set to True, the coadd bbox is a simple box bounded by 
+        (0,0,coadd_dim,coadd_dim), and the coadd and SE WCS have the same 
+        world origin. If set to False, the coadd bbox is embeded in a larger 
+        box bounded by (xoff, yoff, xoff+coadd_dim, yoff+coadd_dim) and 
+        the SE WCS has a different world origin as coadd WCS.  
     draw_noise: optional, bool
         Whether draw image noise
 
@@ -174,10 +181,17 @@ def make_sim(
                 "coadd_dim should be int when galaxy catalog does not",
                 "have attribute 'layout'",
             )
-        coadd_wcs, coadd_bbox = make_coadd_dm_wcs(
-            coadd_dim,
-            pixel_scale=pixel_scale,
-        )
+        if simple_coadd_bbox:
+            coadd_wcs, coadd_bbox = make_coadd_dm_wcs_simple(
+                coadd_dim,
+                pixel_scale=pixel_scale,
+            )
+        else:
+            coadd_wcs, coadd_bbox = make_coadd_dm_wcs(
+                coadd_dim,
+                pixel_scale=pixel_scale,
+            )
+
     coadd_bbox_cen_gs_skypos = get_coadd_center_gs_pos(
         coadd_wcs=coadd_wcs,
         coadd_bbox=coadd_bbox,

--- a/descwl_shear_sims/sim.py
+++ b/descwl_shear_sims/sim.py
@@ -140,7 +140,7 @@ def make_sim(
         (0,0,coadd_dim,coadd_dim), and the coadd and SE WCS have the same
         world origin. If set to False, the coadd bbox is embeded in a larger
         box bounded by (xoff, yoff, xoff+coadd_dim, yoff+coadd_dim) and
-        the SE WCS has a different world origin as coadd WCS.
+        the SE WCS has a different world origin compared to the coadd WCS.
     draw_noise: optional, bool
         Whether draw image noise
 
@@ -454,12 +454,22 @@ def make_exp(
         theta = None
 
     # galsim wcs
-    se_wcs = make_wcs(
-        scale=pixel_scale,
-        theta=theta,
-        image_origin=se_origin,
-        world_origin=coadd_bbox_cen_gs_skypos,
-    )
+    # if simple coadd bbox, force the SE WCS to share the same 
+    # world origin as the coadd WCS 
+    if simple_coadd_bbox:
+        se_wcs = make_wcs(
+            scale=pixel_scale,
+            theta=theta,
+            image_origin=se_origin,
+            world_origin=WORLD_ORIGIN,
+        )
+    else:
+        se_wcs = make_wcs(
+            scale=pixel_scale,
+            theta=theta,
+            image_origin=se_origin,
+            world_origin=coadd_bbox_cen_gs_skypos,
+        )
 
     image = galsim.Image(dim, dim, wcs=se_wcs)
 

--- a/descwl_shear_sims/sim.py
+++ b/descwl_shear_sims/sim.py
@@ -459,8 +459,8 @@ def make_exp(
         theta = None
 
     # galsim wcs
-    # if simple coadd bbox, force the SE WCS to share the same 
-    # world origin as the coadd WCS 
+    # if simple coadd bbox, force the SE WCS to share the same
+    # world origin as the coadd WCS
     if simple_coadd_bbox:
         se_wcs = make_wcs(
             scale=pixel_scale,

--- a/descwl_shear_sims/tests/test_dmwcs.py
+++ b/descwl_shear_sims/tests/test_dmwcs.py
@@ -123,7 +123,6 @@ def test_same_world_origin_se_coadd_wcs_simple():
     cen = (np.array(dims) + 1) / 2
     se_origin = galsim.PositionD(x=cen[1], y=cen[0])
 
-
     masked_image = afw_image.MaskedImageF(coadd_dim, coadd_dim)
     exp = afw_image.ExposureF(masked_image)
 

--- a/descwl_shear_sims/tests/test_dmwcs.py
+++ b/descwl_shear_sims/tests/test_dmwcs.py
@@ -2,8 +2,9 @@ import numpy as np
 import galsim
 import lsst.afw.image as afw_image
 import lsst.geom as geom
-from ..wcs import make_dm_wcs, make_coadd_dm_wcs_simple
+from ..wcs import make_wcs, make_dm_wcs, make_coadd_dm_wcs_simple
 from ._wcs import make_sim_wcs, SCALE
+from ..sim import get_coadd_center_gs_pos
 
 
 def test_dmwcs():
@@ -47,10 +48,12 @@ def test_dmwcs():
     # stop
 
     assert np.allclose(
-        skypos.getRa().asRadians(), gs_skypos.ra / galsim.radians,
+        skypos.getRa().asRadians(),
+        gs_skypos.ra / galsim.radians,
     )
     assert np.allclose(
-        skypos.getDec().asRadians(), gs_skypos.dec / galsim.radians,
+        skypos.getDec().asRadians(),
+        gs_skypos.dec / galsim.radians,
     )
 
     impos = dm_wcs.skyToPixel(skypos)
@@ -97,12 +100,64 @@ def test_coadd_dmwcs_simple():
     print("galsim sky position ra dec", gs_skypos.ra, gs_skypos.dec)
 
     assert np.allclose(
-        skypos.getRa().asRadians(), gs_skypos.ra / galsim.radians,
+        skypos.getRa().asRadians(),
+        gs_skypos.ra / galsim.radians,
     )
     assert np.allclose(
-        skypos.getDec().asRadians(), gs_skypos.dec / galsim.radians,
+        skypos.getDec().asRadians(),
+        gs_skypos.dec / galsim.radians,
     )
 
     impos = dm_coadd_wcs_simple.skyToPixel(skypos)
     assert np.allclose(impos.x, x - 1)
     assert np.allclose(impos.y, y - 1)
+
+
+def test_same_world_origin_se_coadd_wcs_simple():
+    se_dim = 30
+    coadd_dim = 20
+
+    dims = [se_dim] * 2
+    # Galsim uses 1 offset. An array with length =dim=5
+    # The center is at 3=(5+1)/2
+    cen = (np.array(dims) + 1) / 2
+    se_origin = galsim.PositionD(x=cen[1], y=cen[0])
+
+
+    masked_image = afw_image.MaskedImageF(coadd_dim, coadd_dim)
+    exp = afw_image.ExposureF(masked_image)
+
+    tcoadd_dm_wcs_simple, coadd_bbox = make_coadd_dm_wcs_simple(coadd_dim, SCALE)
+
+    exp.setWcs(tcoadd_dm_wcs_simple)
+
+    dm_coadd_wcs_simple = exp.getWcs()
+
+    coadd_bbox_cen_gs_skypos = get_coadd_center_gs_pos(
+        coadd_wcs=dm_coadd_wcs_simple,
+        coadd_bbox=coadd_bbox,
+    )
+
+    se_wcs = make_wcs(
+        scale=SCALE,
+        theta=0,
+        image_origin=se_origin,
+        world_origin=coadd_bbox_cen_gs_skypos,
+    )
+    dm_se_wcs = make_dm_wcs(se_wcs)
+
+    se_sky_origin = dm_se_wcs.getSkyOrigin()
+    coadd_sky_origin = dm_coadd_wcs_simple.getSkyOrigin()
+
+    print("se sky origin", se_sky_origin)
+    print("coadd sky origin", coadd_sky_origin)
+
+    assert np.allclose(
+        se_sky_origin.getRa().asRadians(),
+        coadd_sky_origin.getRa().asRadians(),
+    )
+
+    assert np.allclose(
+        se_sky_origin.getDec().asRadians(),
+        coadd_sky_origin.getDec().asRadians(),
+    )


### PR DESCRIPTION
Hi!

This PR adds an optional keyword argument in `make_sim` to enable switching between `make_coadd_dm_wcs` and `make_coadd_dm_wcs_simple`. The latter uses no padding and offset in making DM WCS and bbox, and the resulting world origins of SE WCS and coadd WCS are the same. 

I added a test to check if the world origins of SE and coadd are the same when using `make_coadd_dm_wcs_simple`. 

Thanks!