### PR TITLE
Return prelensed coordinates, kappa, and gamma

### DIFF
--- a/descwl_shear_sims/sim.py
+++ b/descwl_shear_sims/sim.py
@@ -621,6 +621,8 @@ def _draw_objects(
         )
 
         image_pos = wcs.toImage(world_pos)
+        original_image_pos = wcs.toImage(original_world_pos)
+
         local_wcs = wcs.local(image_pos=image_pos)
 
         convolved_object = get_convolved_object(obj, psf, image_pos)
@@ -642,6 +644,8 @@ def _draw_objects(
         info["z"] = (z,)
         info["image_x"] = (image_pos.x - 1,)
         info["image_y"] = (image_pos.y - 1,) 
+        info["original_image_x"] = (original_image_pos.x - 1,)
+        info["original_image_y"] = (original_image_pos.y - 1,)
         if shear_halo:
             info["original_ra"] = original_world_pos.ra / galsim.degrees
             info["original_dec"] = original_world_pos.dec / galsim.degrees
@@ -918,6 +922,8 @@ def get_truth_info_struct(type="shear"):
     ]
     if type == "cluster":
         dt += [
+            ("original_image_x", "f8"),
+            ("original_image_y", "f8"),
             ("original_ra", "f8"),
             ("original_dec", "f8"),
             ("kappa", "f8"),

--- a/descwl_shear_sims/sim.py
+++ b/descwl_shear_sims/sim.py
@@ -605,7 +605,7 @@ def _draw_objects(
                 obj, shift = shear_obj.distort_galaxy(obj, shift, z)
             else:
                 shear_halo = True
-                obj, shift, orignal_shift, gamma1, gamma2, kappa = (
+                obj, shift, prelensed_shift, gamma1, gamma2, kappa = (
                     shear_obj.distort_galaxy(obj, shift, z)
                 )
 
@@ -615,13 +615,14 @@ def _draw_objects(
             shift.y * galsim.arcsec,
         )
 
-        original_world_pos = coadd_bbox_cen_gs_skypos.deproject(
-            orignal_shift.x * galsim.arcsec,
-            orignal_shift.y * galsim.arcsec,
-        )
-
         image_pos = wcs.toImage(world_pos)
-        original_image_pos = wcs.toImage(original_world_pos)
+
+        if prelensed_shift is not None:
+            prelensed_world_pos = coadd_bbox_cen_gs_skypos.deproject(
+                prelensed_shift.x * galsim.arcsec,
+                prelensed_shift.y * galsim.arcsec,
+            )
+            original_image_pos = wcs.toImage(prelensed_world_pos)
 
         local_wcs = wcs.local(image_pos=image_pos)
 
@@ -635,7 +636,7 @@ def _draw_objects(
         if b.isDefined():
             image[b] += stamp[b]
         if shear_halo:
-            info = get_truth_info_struct(type="cluster")
+            info = get_truth_info_struct(type="halo")
         else:
             info = get_truth_info_struct()
         info["index"] = (ind,)
@@ -643,12 +644,12 @@ def _draw_objects(
         info["dec"] = world_pos.dec / galsim.degrees
         info["z"] = (z,)
         info["image_x"] = (image_pos.x - 1,)
-        info["image_y"] = (image_pos.y - 1,) 
-        info["original_image_x"] = (original_image_pos.x - 1,)
-        info["original_image_y"] = (original_image_pos.y - 1,)
+        info["image_y"] = (image_pos.y - 1,)
+        info["prelensed_image_x"] = (original_image_pos.x - 1,)
+        info["prelensed_image_y"] = (original_image_pos.y - 1,)
         if shear_halo:
-            info["original_ra"] = original_world_pos.ra / galsim.degrees
-            info["original_dec"] = original_world_pos.dec / galsim.degrees
+            info["prelensed_ra"] = prelensed_world_pos.ra / galsim.degrees
+            info["prelensed_dec"] = prelensed_world_pos.dec / galsim.degrees
             info["gamma1"] = (gamma1,)
             info["gamma2"] = (gamma2,)
             info["kappa"] = (kappa,)
@@ -920,7 +921,7 @@ def get_truth_info_struct(type="shear"):
         ("image_x", "f8"),
         ("image_y", "f8"),
     ]
-    if type == "cluster":
+    if type == "halo":
         dt += [
             ("original_image_x", "f8"),
             ("original_image_y", "f8"),

--- a/descwl_shear_sims/sim.py
+++ b/descwl_shear_sims/sim.py
@@ -906,7 +906,7 @@ def get_truth_info_struct():
         ("image_y", "f8"),
         ("original_ra", "f8"),
         ("original_dec", "f8"),
-        ("kappa", "f8")
+        ("kappa", "f8"),
         ("gamma1", "f8"),
         ("gamma2", "f8"),
     ]

--- a/descwl_shear_sims/sim.py
+++ b/descwl_shear_sims/sim.py
@@ -599,12 +599,17 @@ def _draw_objects(
             shift = _roate_pos(shift, theta0)
 
         if shear_obj is not None:
-            obj, shift = shear_obj.distort_galaxy(obj, shift, z)
+            obj, shift, orignal_shift, gamma1, gamma2, kappa = shear_obj.distort_galaxy(obj, shift, z)
 
         # Deproject from u,v onto sphere. Then use wcs to get to image pos.
         world_pos = coadd_bbox_cen_gs_skypos.deproject(
             shift.x * galsim.arcsec,
             shift.y * galsim.arcsec,
+        )
+
+        original_world_pos = coadd_bbox_cen_gs_skypos.deproject(
+            orignal_shift.x * galsim.arcsec,
+            orignal_shift.y * galsim.arcsec,
         )
 
         image_pos = wcs.toImage(world_pos)
@@ -624,6 +629,11 @@ def _draw_objects(
         info["index"] = (ind,)
         info["ra"] = world_pos.ra / galsim.degrees
         info["dec"] = world_pos.dec / galsim.degrees
+        info["original_ra"] = original_world_pos.ra / galsim.degrees
+        info["original_dec"] = original_world_pos.dec / galsim.degrees
+        info["gamma1"] = (gamma1,)
+        info["gamma2"] = (gamma2,)
+        info["kappa"] = (kappa,)
         info["z"] = (z,)
         info["image_x"] = (image_pos.x - 1,)
         info["image_y"] = (image_pos.y - 1,)
@@ -894,6 +904,11 @@ def get_truth_info_struct():
         ("z", "f8"),
         ("image_x", "f8"),
         ("image_y", "f8"),
+        ("original_ra", "f8"),
+        ("original_dec", "f8"),
+        ("kappa", "f8")
+        ("gamma1", "f8"),
+        ("gamma2", "f8"),
     ]
     return np.zeros(1, dtype=dt)
 


### PR DESCRIPTION
Hi!

@mr-superonion and I are doing tests with cluster shear. It would be really helpful if we could get prelensed coordinates, κ and γ for each source. I implemented some code to return these quantities if the shear object is a `ShearHalo` from https://github.com/mr-superonion/xlens/blob/main/xlens/simulator/perturbation/halo.py . The code is a bit unwieldy now, but the changes do not impact other functionalities, I think. Let me know if any changes need to be made. Thanks! 