### PR TITLE
Add simple coadd bbox to layout and galaxy catalogs

### DIFF
--- a/descwl_shear_sims/galaxies.py
+++ b/descwl_shear_sims/galaxies.py
@@ -175,7 +175,7 @@ class FixedGalaxyCatalog(object):
         Separation of galaxies in arcsec
     simple_coadd_bbox: optional, bool. Default: False
         Whether to force the center of coadd boundary box (which is the default
-        center single exposure) at the world_origin 
+        center single exposure) at the world_origin
     """
     def __init__(
         self, *,
@@ -196,7 +196,8 @@ class FixedGalaxyCatalog(object):
         self.hlr = hlr
 
         if isinstance(layout, str):
-            self.layout = Layout(layout, coadd_dim, buff, pixel_scale, simple_coadd_bbox=simple_coadd_bbox)
+            self.layout = Layout(layout, coadd_dim, buff, pixel_scale,
+                                 simple_coadd_bbox=simple_coadd_bbox)
         else:
             assert isinstance(layout, Layout)
             self.layout = layout

--- a/descwl_shear_sims/galaxies.py
+++ b/descwl_shear_sims/galaxies.py
@@ -28,6 +28,7 @@ def make_galaxy_catalog(
     layout: Layout | str | None = None,
     gal_config=None,
     sep=None,
+    simple_coadd_bbox=False,
 ):
     """
     rng: numpy.random.RandomState
@@ -49,6 +50,9 @@ def make_galaxy_catalog(
         for defaults mag, hlr and morph
     sep: float, optional
         Separation of pair in arcsec for layout='pair', 'grid' or 'hex'
+    simple_coadd_bbox: optional, bool. Default: False
+        Whether to force the center of coadd boundary box (which is the default
+        center single exposure) at the world_origin
     """
 
     if layout is None and gal_type == 'wldeblend':
@@ -60,6 +64,7 @@ def make_galaxy_catalog(
             coadd_dim=coadd_dim,
             buff=buff,
             pixel_scale=pixel_scale,
+            simple_coadd_bbox=simple_coadd_bbox,
         )
     else:
         assert isinstance(layout, Layout)
@@ -168,6 +173,9 @@ class FixedGalaxyCatalog(object):
         pixel scale in arcsec
     sep: float | None
         Separation of galaxies in arcsec
+    simple_coadd_bbox: optional, bool. Default: False
+        Whether to force the center of coadd boundary box (which is the default
+        center single exposure) at the world_origin 
     """
     def __init__(
         self, *,
@@ -180,6 +188,7 @@ class FixedGalaxyCatalog(object):
         buff=0,
         pixel_scale=SCALE,
         sep=None,
+        simple_coadd_bbox=False,
     ):
         self.gal_type = 'fixed'
         self.morph = morph
@@ -187,7 +196,7 @@ class FixedGalaxyCatalog(object):
         self.hlr = hlr
 
         if isinstance(layout, str):
-            self.layout = Layout(layout, coadd_dim, buff, pixel_scale)
+            self.layout = Layout(layout, coadd_dim, buff, pixel_scale, simple_coadd_bbox=simple_coadd_bbox)
         else:
             assert isinstance(layout, Layout)
             self.layout = layout
@@ -292,6 +301,9 @@ class GalaxyCatalog(FixedGalaxyCatalog):
         pixel scale in arcsec
     sep: float | None
         Separation of galaxies in arcsec
+    simple_coadd_bbox: optional, bool. Default: False
+        Whether to force the center of coadd boundary box (which is the default
+        center single exposure) at the world_origin
     """
     def __init__(
         self, *,
@@ -304,6 +316,7 @@ class GalaxyCatalog(FixedGalaxyCatalog):
         buff=0,
         pixel_scale=SCALE,
         sep=None,
+        simple_coadd_bbox=False,
     ):
         super().__init__(
             rng=rng,
@@ -315,6 +328,7 @@ class GalaxyCatalog(FixedGalaxyCatalog):
             hlr=hlr,
             morph=morph,
             sep=sep,
+            simple_coadd_bbox=simple_coadd_bbox,
         )
         self.gal_type = 'varying'
 
@@ -569,15 +583,17 @@ class FixedPairGalaxyCatalog(FixedGalaxyCatalog):
         Separation of pair in arcsec
     morph: str
         Galaxy morphology, 'exp', 'dev' or 'bd', 'bdk'.  Default 'exp'
+    simple_coadd_bbox: optional, bool. Default: False
+        Whether to force the center of coadd boundary box (which is the default
+        center single exposure) at the world_origin
     """
-    def __init__(self, *, rng, mag, hlr, sep, morph='exp'):
+    def __init__(self, *, rng, mag, hlr, sep, morph='exp', simple_coadd_bbox=False):
         self.gal_type = 'fixed'
         self.morph = morph
         self.mag = mag
         self.hlr = hlr
         self.rng = rng
-
-        self.layout = Layout("pair")
+        self.layout = Layout("pair", simple_coadd_bbox=simple_coadd_bbox)
         self.shifts_array = self.layout.get_shifts(
             rng=rng,
             sep=sep,

--- a/descwl_shear_sims/galaxies.py
+++ b/descwl_shear_sims/galaxies.py
@@ -652,6 +652,9 @@ class WLDeblendGalaxyCatalog(object):
     indice_id: None | int
         galaxy index to use, use galaxies in the range between indice_id * num
         and (indice_id + 1) * num
+    simple_coadd_bbox: optional, bool. Default: False
+        Whether to force the center of coadd boundary box (which is the default
+        center single exposure) at the world_origin
     """
     def __init__(
         self,
@@ -666,6 +669,7 @@ class WLDeblendGalaxyCatalog(object):
         select_upper_limit=None,
         sep=None,
         indice_id=None,
+        simple_coadd_bbox=False,
     ):
         self.gal_type = 'wldeblend'
         self.rng = rng
@@ -681,7 +685,8 @@ class WLDeblendGalaxyCatalog(object):
         if buff is None:
             buff = 0
         if isinstance(layout, str):
-            self.layout = Layout(layout, coadd_dim, buff, pixel_scale)
+            self.layout = Layout(layout, coadd_dim, buff, pixel_scale,
+                                 simple_coadd_bbox=simple_coadd_bbox)
         else:
             assert isinstance(layout, Layout)
             self.layout = layout

--- a/descwl_shear_sims/sim.py
+++ b/descwl_shear_sims/sim.py
@@ -695,6 +695,10 @@ def _draw_objects(
         info["index"] = (ind,)
         info["ra"] = world_pos.ra / galsim.degrees
         info["dec"] = world_pos.dec / galsim.degrees
+        info["shift_x"] = (shift.x,)
+        info["shift_y"] = (shift.y,)
+        info["lensed_shift_x"] = (lensed_shift.x,)
+        info["lensed_shift_y"] = (lensed_shift.y,)
         info["z"] = (z,)
         info["image_x"] = (image_pos.x - 1,)
         info["image_y"] = (image_pos.y - 1,)
@@ -967,6 +971,10 @@ def get_truth_info_struct():
         ("index", "i4"),
         ("ra", "f8"),
         ("dec", "f8"),
+        ("shift_x", "f8"),
+        ("shift_y", "f8"),
+        ("lensed_shift_x", "f8"),
+        ("lensed_shift_y", "f8"),
         ("z", "f8"),
         ("image_x", "f8"),
         ("image_y", "f8"),

--- a/descwl_shear_sims/tests/test_sim.py
+++ b/descwl_shear_sims/tests/test_sim.py
@@ -690,14 +690,14 @@ def test_sim_truth_info():
         survey_name=survey_name,
     )
     assert "truth_info" in out.keys()
-    assert out["truth_info"].dtype.names == (
+    assert set(out["truth_info"].dtype.names) == {
         'index', 'ra', 'dec', 'z', 'image_x', 'image_y',
         'prelensed_image_x', 'prelensed_image_y',
         'prelensed_ra', 'prelensed_dec',
         'shift_x', 'shift_y',
         'lensed_shift_x', 'lensed_shift_y',
         'kappa', 'gamma1', 'gamma2'
-    )
+    }
     np.testing.assert_allclose(
         galaxy_catalog.indices,
         out["truth_info"]["index"],

--- a/descwl_shear_sims/tests/test_sim.py
+++ b/descwl_shear_sims/tests/test_sim.py
@@ -694,6 +694,8 @@ def test_sim_truth_info():
         'index', 'ra', 'dec', 'z', 'image_x', 'image_y',
         'prelensed_image_x', 'prelensed_image_y',
         'prelensed_ra', 'prelensed_dec',
+        'shift_x', 'shift_y',
+        'lensed_shift_x', 'lensed_shift_y',
         'kappa', 'gamma1', 'gamma2'
     )
     np.testing.assert_allclose(


### PR DESCRIPTION
There are two places WCS can be set. It is optimal that both of these places can have simple coadd bbox option. Also sometimes there could be coordinate inconsistency if `simple_coadd_bbox` is set in `make_sim` but not in the input galaxy catalog. 

In addition, I added shifts in the returned catalog for testing WCS, projection, and deprojection. 