### PR TITLE
Remove acyclic dependencies

### DIFF
--- a/ups/descwl_shear_sims.table
+++ b/ups/descwl_shear_sims.table
@@ -11,7 +11,6 @@ setupRequired(meas_algorithms)
 
 # Optional dependencies, for testing only
 setupOptional(descwl_coadd)
-setupOptional(metadetect)
 
 # The following is boilerplate for all packages.
 # See https://dmtn-001.lsst.io for details on LSST_LIBRARY_PATH.


### PR DESCRIPTION
The optional setup didn't do what I thought it did. This is now specialized to the case where I assume we setup `metadetect` that triggers this setup, and one doesn't try to setup this package directly.