### PR TITLE
Add no_layout option in Layout

### DIFF
--- a/descwl_shear_sims/layout/layout.py
+++ b/descwl_shear_sims/layout/layout.py
@@ -36,7 +36,9 @@ class Layout(object):
         Parameters
         ----------
         layout_name: string
-            'grid', 'pair', 'hex', or 'random'
+            'grid', 'pair', 'hex', 'no_layout', or 'random',
+            'no_layout' needs users to specify the shifts
+            when constructing the galaxy catalog.
         coadd_dim: int | None
             Dimensions of final coadd
         buff: int, optional

--- a/descwl_shear_sims/layout/layout.py
+++ b/descwl_shear_sims/layout/layout.py
@@ -85,9 +85,11 @@ class Layout(object):
             self.area = 0
         elif layout_name == "pair":
             return
+        elif layout_name == "no_layout":
+            pass
         else:
             raise ValueError("layout_name can only be 'random', 'random_disk' \
-                    'hex', 'grid' or 'pair'!")
+                    'hex', 'grid', 'no_layout'  or 'pair'!")
         self.coadd_dim = coadd_dim
         self.buff = buff
 
@@ -183,6 +185,10 @@ class Layout(object):
                     buff=self.buff,
                     pixel_scale=self.pixel_scale,
                     size=nobj,
+                )
+            elif self.layout_name == "no_layout":
+                raise NotImplementedError(
+                    "get_shifts is not implemented for layout 'no_layout'. "
                 )
             else:
                 raise ValueError("bad layout: '%s'" % self.layout_name)


### PR DESCRIPTION
This is an updated version of https://github.com/LSSTDESC/descwl-shear-sims/pull/233 following @esheldon 's suggestions. By creating this `CustomGalaxyCatalog`, users can specify where they would like to put the galaxy. We just need to disable `get_shifts` since the shifts are specified in the galaxy catalog construction. 

```
class CustomGalaxyCatalog(object):
    """
    Catalog that uses an explicit list of galsim objects and (u, v) shifts.

    Parameters
    ----------
    gal_list : list[galsim.GSObject]
        The galaxies to place.
    uv_shift : list[tuple[float, float]]
        Per-galaxy (u, v) shifts in arcsec, same length as gal_list.
    layout : Layout | None
        Optional; only used to carry coadd bbox/world origin metadata.
        Positions are taken strictly from `uv_shift`.
    """
    def __init__(self, *, gal_list, uv_shift, coadd_dim, pixel_scale,
                 simple_coadd_bbox, layout=None):
        if gal_list is None or len(gal_list) == 0:
            raise ValueError("gal_list must be a non-empty list of galsim objects")
        if uv_shift is None or len(uv_shift) != len(gal_list):
            raise ValueError("uv_shift must be provided and match len(gal_list)")
        self.gal_type = 'fixed'
        self._gal_list = list(gal_list)
        self._shifts = [galsim.PositionD(u, v) for (u, v) in uv_shift]

        buff = 0  # ignored since positions are explicit

        if isinstance(layout, str):
            self.layout = Layout(layout, coadd_dim, buff, pixel_scale,
                                 simple_coadd_bbox=simple_coadd_bbox)
        else:
            assert isinstance(layout, Layout)
            self.layout = layout

    def __len__(self):
        return len(self._gal_list)

    def get_objlist(self, *, survey):
        """
        Returns a dict with the same structure as other catalogs.
        The provided GSObjects are used verbatim (no flux remapping).
        """
        indexes = list(range(len(self._gal_list)))
        return {
            "objlist": list(self._gal_list),
            "shifts": list(self._shifts),
            "redshifts": None,
            "indexes": indexes,
        }
```