### PR TITLE
Add support for any PSF with getPSF

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
     - Can specify variation parameters for make_rand_psf
     - add psf_fwhm to default sim config (a convenience for users)
     - add tests
+    - Generalize to support any PSF that has the getPSF method.  
+      Rename PowerSpectrumDMPSF to DMPSF (but keep an alias)
 
 # 0.4.5
 ### new features

--- a/descwl_shear_sims/psfs/__init__.py
+++ b/descwl_shear_sims/psfs/__init__.py
@@ -3,4 +3,4 @@ from . import ps_psf
 from .ps_psf import PowerSpectrumPSF, make_ps_psf
 from .fixed_psf import FixedPSF, make_fixed_psf
 from .rand_psf import make_rand_psf
-from .dmpsfs import FixedDMPSF, PowerSpectrumDMPSF, make_dm_psf
+from .dmpsfs import FixedDMPSF, DMPSF, PowerSpectrumDMPSF, make_dm_psf

--- a/descwl_shear_sims/psfs/dmpsfs.py
+++ b/descwl_shear_sims/psfs/dmpsfs.py
@@ -3,7 +3,6 @@ import galsim
 import lsst.afw.image as afw_image
 import lsst.geom as geom
 from lsst.meas.algorithms import ImagePsf
-from .ps_psf import PowerSpectrumPSF
 
 
 def make_dm_psf(psf, psf_dim, wcs):
@@ -12,7 +11,7 @@ def make_dm_psf(psf, psf_dim, wcs):
 
     Parameters
     ----------
-    psf: GSObject or PowerSpectrumPSF
+    psf: GSObject or object with getPSF method such as PowerSpectrumPSF
         The sim psf
     psf_dim: int
         Dimension of the psfs to draw, must be odd
@@ -21,14 +20,12 @@ def make_dm_psf(psf, psf_dim, wcs):
 
     Returns
     -------
-    Either a FixedDMPSF or a PowerSpectrumDMPSF
+    Either a FixedDMPSF or a DMPSF
     """
     if isinstance(psf, galsim.GSObject):
         return FixedDMPSF(psf, psf_dim, wcs)
-    elif isinstance(psf, PowerSpectrumPSF):
-        return PowerSpectrumDMPSF(psf, psf_dim, wcs)
     else:
-        raise ValueError('bad psf: %s' % type(psf))
+        return DMPSF(psf, psf_dim, wcs)
 
 
 class FixedDMPSF(ImagePsf):
@@ -149,7 +146,7 @@ class FixedDMPSF(ImagePsf):
             wcs=self._wcs.local(image_pos=gs_pos),
         )
 
-        dims = [dim]*2
+        dims = [dim] * 2
 
         off = -(dim // 2)
         if is_kernel:
@@ -168,19 +165,19 @@ class FixedDMPSF(ImagePsf):
         return aimage
 
 
-class PowerSpectrumDMPSF(FixedDMPSF):
+class DMPSF(FixedDMPSF):
     """
     A class representing a power spectrum psf
 
     When offsetting no image interpolation is done.  Real psfs have an
     interpolation to offset (different from interpolating coefficients)
     """
-    def __init__(self, pspsf, psf_dim, wcs):
+    def __init__(self, psf, psf_dim, wcs):
         """
         Parameters
         ----------
-        pspsf: PowerSpectrumPSF
-            The power spectrum psf
+        psf: psf object
+            Object with getPSF method that returns a galsim objet
         psf_dim: int
             Dimension of the psfs to draw, must be odd
         wcs: galsim WCS
@@ -193,7 +190,7 @@ class PowerSpectrumDMPSF(FixedDMPSF):
 
         self._psf_dim = psf_dim
         self._wcs = wcs
-        self._pspsf = pspsf
+        self._psf = psf
 
     def _get_gspsf(self, pos):
         """
@@ -206,4 +203,7 @@ class PowerSpectrumDMPSF(FixedDMPSF):
             The position at which to evaluate the psf.
         """
 
-        return self._pspsf.getPSF(pos)
+        return self._psf.getPSF(pos)
+
+
+PowerSpectrumDMPSF = DMPSF

--- a/descwl_shear_sims/sim.py
+++ b/descwl_shear_sims/sim.py
@@ -115,8 +115,8 @@ def make_sim(
     dither_size: float, optional
         The amplitude of dithering in unit of a fraction of a pixel
         for testing pixel interpolation.
-        All SE WCS will be given random dithers with this amplitude in both image
-        x and y direction.
+        All SE WCS will be given random dithers with this amplitude in both
+        image x and y direction.
         Value must be between 0 and 1.  default 0.5.
     rotate: bool, optional
         Whether to randomly rotate the image exposures randomly [not the
@@ -252,7 +252,9 @@ def make_sim(
             survey_name=survey_name,
         )
         noise_for_gsparams = survey.noise * noise_factor
-        noise_per_epoch = survey.noise * np.sqrt(epochs_per_band) * noise_factor
+        noise_per_epoch = (
+            survey.noise * np.sqrt(epochs_per_band) * noise_factor
+        )
 
         # go down to coadd depth in this band, not dividing by sqrt(nbands)
         # but we could if we want to be more conservative

--- a/descwl_shear_sims/tests/test_dmpsfs_sim.py
+++ b/descwl_shear_sims/tests/test_dmpsfs_sim.py
@@ -1,0 +1,71 @@
+import numpy as np
+import galsim
+
+from ..psfs import PowerSpectrumPSF
+from ..sim import make_sim
+from ..galaxies import make_galaxy_catalog
+from ..shear import ShearConstant
+
+
+class TestPSF:
+    """
+    Something that meets the interface getPSF
+    """
+    def getPSF(self, psf):
+        return galsim.Gaussian(fwhm=1)
+
+
+def test_dmpsf_smoke():
+    rng = np.random.RandomState(seed=10)
+
+    shear_obj = ShearConstant(g1=0.02, g2=0.)
+    psf = TestPSF()
+
+    galaxy_catalog = make_galaxy_catalog(
+        rng=rng,
+        gal_type="fixed",
+        coadd_dim=300,
+        buff=30,
+        layout="grid",
+    )
+
+    _ = make_sim(
+        rng=rng,
+        galaxy_catalog=galaxy_catalog,
+        coadd_dim=300,
+        psf_dim=51,
+        bands=['r'],
+        shear_obj=shear_obj,
+        psf=psf,
+    )
+
+
+def test_dmpsf_ps_smoke():
+    rng = np.random.RandomState(seed=10)
+
+    shear_obj = ShearConstant(g1=0.02, g2=0.)
+    psf = PowerSpectrumPSF(
+        rng=rng,
+        im_width=120,
+        buff=20,
+        scale=0.2,
+        trunc=10,
+    )
+
+    galaxy_catalog = make_galaxy_catalog(
+        rng=rng,
+        gal_type="fixed",
+        coadd_dim=300,
+        buff=30,
+        layout="grid",
+    )
+
+    _ = make_sim(
+        rng=rng,
+        galaxy_catalog=galaxy_catalog,
+        coadd_dim=300,
+        psf_dim=51,
+        bands=['r'],
+        shear_obj=shear_obj,
+        psf=psf,
+    )


### PR DESCRIPTION
    
    The PowerSpectrumDMPSF is actually general for anything that has the
    getPSF method.  Make the code do duck typing for anything that
    isn't GSObject
    
    Rename to DMPSF and make PowerSpectrumDMPSF an alias to it.

    Add tests