### PR TITLE
Pass draw_method on to dmpsfs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,11 @@
     - Generalize to support any PSF that has the getPSF method.  
       Rename PowerSpectrumDMPSF to DMPSF (but keep an alias)
 
+### Bug Fixes
+
+    - draw_method was not passed on to DM PSFs.  Only passed on
+      if not equal to 'phot'
+
 # 0.4.5
 ### new features
     - allow users to set separation distance for grid and hex layout

--- a/descwl_shear_sims/psfs/dmpsfs.py
+++ b/descwl_shear_sims/psfs/dmpsfs.py
@@ -5,7 +5,7 @@ import lsst.geom as geom
 from lsst.meas.algorithms import ImagePsf
 
 
-def make_dm_psf(psf, psf_dim, wcs):
+def make_dm_psf(psf, psf_dim, wcs, draw_method='auto'):
     """
     convert a sim PSF to a DM Stack PSF
 
@@ -17,15 +17,17 @@ def make_dm_psf(psf, psf_dim, wcs):
         Dimension of the psfs to draw, must be odd
     wcs: galsim WCS
         WCS for drawing
+    draw_method: str, optional
+        Galsim draw method, Defaults to 'auto'
 
     Returns
     -------
     Either a FixedDMPSF or a DMPSF
     """
     if isinstance(psf, galsim.GSObject):
-        return FixedDMPSF(psf, psf_dim, wcs)
+        return FixedDMPSF(psf, psf_dim=psf_dim, wcs=wcs, draw_method=draw_method)
     else:
-        return DMPSF(psf, psf_dim, wcs)
+        return DMPSF(psf, psf_dim=psf_dim, wcs=wcs, draw_method=draw_method)
 
 
 class FixedDMPSF(ImagePsf):
@@ -35,7 +37,7 @@ class FixedDMPSF(ImagePsf):
     When offsetting no image interpolation is done.  Real psfs have an
     interpolation to offset (different from interpolating coefficients)
     """
-    def __init__(self, gspsf, psf_dim, wcs):
+    def __init__(self, gspsf, psf_dim, wcs, draw_method='auto'):
         """
         Parameters
         ----------
@@ -45,6 +47,8 @@ class FixedDMPSF(ImagePsf):
             Dimension of the psfs to draw, must be odd
         wcs: galsim WCS
             WCS for drawing
+        draw_method: str, optional
+            Galsim draw method, Defaults to 'auto'
         """
         ImagePsf.__init__(self)
 
@@ -54,6 +58,7 @@ class FixedDMPSF(ImagePsf):
         self._psf_dim = psf_dim
         self._wcs = wcs
         self._gspsf = gspsf
+        self._draw_method = draw_method
 
     def computeImage(self, image_pos):  # noqa
         """
@@ -144,6 +149,7 @@ class FixedDMPSF(ImagePsf):
             ny=dim,
             offset=offset,
             wcs=self._wcs.local(image_pos=gs_pos),
+            method=self._draw_method,
         )
 
         dims = [dim] * 2
@@ -172,7 +178,7 @@ class DMPSF(FixedDMPSF):
     When offsetting no image interpolation is done.  Real psfs have an
     interpolation to offset (different from interpolating coefficients)
     """
-    def __init__(self, psf, psf_dim, wcs):
+    def __init__(self, psf, psf_dim, wcs, draw_method='auto'):
         """
         Parameters
         ----------
@@ -182,6 +188,8 @@ class DMPSF(FixedDMPSF):
             Dimension of the psfs to draw, must be odd
         wcs: galsim WCS
             WCS for drawing
+        draw_method: str, optional
+            Galsim draw method, Defaults to 'auto'
         """
         ImagePsf.__init__(self)
 
@@ -191,6 +199,7 @@ class DMPSF(FixedDMPSF):
         self._psf_dim = psf_dim
         self._wcs = wcs
         self._psf = psf
+        self._draw_method = draw_method
 
     def _get_gspsf(self, pos):
         """

--- a/descwl_shear_sims/psfs/dmpsfs.py
+++ b/descwl_shear_sims/psfs/dmpsfs.py
@@ -60,6 +60,10 @@ class FixedDMPSF(ImagePsf):
         self._gspsf = gspsf
         self._draw_method = draw_method
 
+    @property
+    def draw_method(self):
+        return self._draw_method
+
     def computeImage(self, image_pos):  # noqa
         """
         compute an image at the specified image position, centered in the

--- a/descwl_shear_sims/sim.py
+++ b/descwl_shear_sims/sim.py
@@ -139,7 +139,8 @@ def make_sim(
         mock up a sky oversubtraction.  Default None.
     draw_method: string, optional
         Draw method for galaxy galsim objects, default 'auto'.  Set to
-        'phot' to get poisson noise.  Note this is much slower.
+        'phot' to get poisson noise, or use 'no_pixel' if the PSF
+        already has the  pixel in it.
     theta0: float, optional
         rotation angle of intrinsic galaxy shapes and positions on the sky,
         default 0, in units of radians
@@ -590,7 +591,7 @@ def make_exp(
         psf=psf,
         psf_dim=psf_dim,
         wcs=se_wcs,
-        draw_method=draw_method,
+        draw_method=draw_method if draw_method != 'phot' else 'auto',
     )
 
     variance = image.copy()

--- a/descwl_shear_sims/sim.py
+++ b/descwl_shear_sims/sim.py
@@ -586,7 +586,12 @@ def make_exp(
         bright_info = []
 
     dm_wcs = make_dm_wcs(se_wcs)
-    dm_psf = make_dm_psf(psf=psf, psf_dim=psf_dim, wcs=se_wcs)
+    dm_psf = make_dm_psf(
+        psf=psf,
+        psf_dim=psf_dim,
+        wcs=se_wcs,
+        draw_method=draw_method,
+    )
 
     variance = image.copy()
     variance.array[:, :] = noise**2

--- a/descwl_shear_sims/tests/test_sim.py
+++ b/descwl_shear_sims/tests/test_sim.py
@@ -477,7 +477,7 @@ def test_sim_star_bleeds():
     )
 
 
-@pytest.mark.parametrize("draw_method", (None, "auto", "phot"))
+@pytest.mark.parametrize("draw_method", (None, "auto", "phot", "no_pixel"))
 def test_sim_draw_method_smoke(draw_method):
     seed = 881
     coadd_dim = 201
@@ -496,7 +496,7 @@ def test_sim_draw_method_smoke(draw_method):
         kw['draw_method'] = draw_method
 
     psf = make_fixed_psf(psf_type="gauss")
-    _ = make_sim(
+    data = make_sim(
         rng=rng,
         galaxy_catalog=galaxy_catalog,
         coadd_dim=coadd_dim,
@@ -504,6 +504,16 @@ def test_sim_draw_method_smoke(draw_method):
         psf=psf,
         **kw
     )
+
+    exp = data['band_data']['i'][0]
+    psf = exp.getPsf()
+
+    if draw_method is None:
+        assert psf.draw_method == 'auto'
+    elif draw_method != 'phot':
+        assert psf.draw_method == draw_method
+    else:
+        assert psf.draw_method == 'auto'
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The draw method should be passed on to DM PSFs so that an extra pixel is not included